### PR TITLE
NodeMinimalEntry should have a single property 'entry'

### DIFF
--- a/src/main/webapp/definitions/alfresco-core.yaml
+++ b/src/main/webapp/definitions/alfresco-core.yaml
@@ -3536,6 +3536,13 @@ definitions:
               $ref: '#/definitions/NodeMinimalEntry'
   NodeMinimalEntry:
     type: object
+    required:
+      - entry
+    properties:
+      entry:
+        $ref: '#/definitions/MinimalNode'
+  MinimalNode:
+    type: object
     properties:
       id:
         type: string


### PR DESCRIPTION
- In common with other *Entry types
- Added MinimalNode type which contains the actual node props previously
  on NodeMinimalEntry

Ref RA-969