### PR TITLE
Add path element to returned properties for nodes

### DIFF
--- a/src/main/webapp/definitions/alfresco-core.yaml
+++ b/src/main/webapp/definitions/alfresco-core.yaml
@@ -4414,6 +4414,24 @@ definitions:
         type: string
       assocType:
         type: string                  
+  PathElement:
+    type: object
+    properties:
+      id:
+        type: string
+      name:
+        type: string
+  PathInfo:
+    type: object
+    properties:
+      elements:
+        type: array
+        items:
+          $ref: '#/definitions/PathElement'
+      name:
+        type: string
+      isComplete:
+        type: boolean
   NodePaging:
     type: object
     properties:
@@ -4484,13 +4502,16 @@ definitions:
         $ref: '#/definitions/UserInfo'
       content:
         $ref: '#/definitions/ContentInfo'
+      path:
+        $ref: '#/definitions/PathElement'
+        required: false
   NodeAssocMinimalEntry:
     type: object
     required:
       - entry
     properties:
       entry:
-        $ref: '#/definitions/NodeAssocMinimal'        
+        $ref: '#/definitions/NodeAssocMinimal'
   NodeAssocMinimal:
     type: object
     properties:


### PR DESCRIPTION
Note this is an optional property, only present when include=paths is specified on
request. However without this property definition this optional information is not visible via a generated API client.