### PR TITLE
APPSREPO-185: Updated "shared links" include parameter object to cont…

### DIFF
--- a/src/main/webapp/definitions/alfresco-core.yaml
+++ b/src/main/webapp/definitions/alfresco-core.yaml
@@ -193,6 +193,7 @@ parameters:
     description: |
       Returns additional information about the shared link, the following optional fields can be requested:
       * allowableOperations
+      * path
     required: false
     type: array
     items:
@@ -4883,7 +4884,6 @@ paths:
       operationId: getSharedLink
       parameters:
         - $ref: '#/parameters/sharedIdParam'
-        - $ref: '#/parameters/sharedLinkEntryIncludeParam'
         - $ref: '#/parameters/fieldsParam'
       produces:
         - application/json


### PR DESCRIPTION
…ain path as well.

    - Also, removed the include parameter from the the "/shared-links/{sharedId}" API, as this endpoint is a noAuth API and we don't support include=allowableOperations and/or path in noAuth mode.

@gavincornwell  could you please review the changes?
Thanks