### PR TITLE
REPO-2983: include extra info for node path elements

### DIFF
--- a/src/main/webapp/definitions/alfresco-core.yaml
+++ b/src/main/webapp/definitions/alfresco-core.yaml
@@ -7438,6 +7438,12 @@ definitions:
         type: string
       name:
         type: string
+      nodeType:
+        type: string
+      aspectNames:
+        type: array
+        items:
+          type: string
   PathInfo:
     type: object
     properties:


### PR DESCRIPTION
Updated the OpenAPI spec. to include the extra info on path elements:

* nodeType (short form, e.g. cm:folder)
* aspectNames (list of short form aspect names, e.g. st:siteContainer)