### PR TITLE
BUILDER-131: Fixed Get Binary Content API Defs.

### DIFF
--- a/src/main/webapp/definitions/alfresco-core.yaml
+++ b/src/main/webapp/definitions/alfresco-core.yaml
@@ -1677,9 +1677,13 @@ paths:
         - $ref: '#/parameters/attachmentParam'
         - $ref: '#/parameters/ifModifiedSinceHeader'
         - $ref: '#/parameters/RangeHeader'
+      produces:
+        - application/octet-stream
       responses:
         '200':
           description: Successful response
+          schema:
+            type: file
         '206':
           description: Partial Content
         '304':
@@ -1951,9 +1955,13 @@ paths:
           required: false
           type: boolean
           default: false
+      produces:
+        - application/octet-stream
       responses:
         '200':
           description: Successful response
+          schema:
+            type: file
         '206':
           description: Partial Content
         '304':
@@ -2559,9 +2567,13 @@ paths:
         - $ref: '#/parameters/attachmentParam'
         - $ref: '#/parameters/ifModifiedSinceHeader'
         - $ref: '#/parameters/RangeHeader'
+      produces:
+        - application/octet-stream
       responses:
         '200':
           description: Successful response
+          schema:
+            type: file
         '206':
           description: Partial Content
         '304':
@@ -2791,9 +2803,13 @@ paths:
         - $ref: '#/parameters/attachmentParam'
         - $ref: '#/parameters/ifModifiedSinceHeader'
         - $ref: '#/parameters/RangeHeader'
+      produces:
+        - application/octet-stream
       responses:
         '200':
           description: Successful response
+          schema:
+            type: file
         '206':
           description: Partial Content
         '304':
@@ -2971,9 +2987,13 @@ paths:
           required: false
           type: boolean
           default: false
+      produces:
+        - application/octet-stream
       responses:
         '200':
           description: Successful response
+          schema:
+            type: file
         '206':
           description: Partial Content
         '304':
@@ -4433,9 +4453,13 @@ paths:
           required: false
           type: boolean
           default: true
+      produces:
+        - application/octet-stream
       responses:
         '200':
           description: Successful response
+          schema:
+            type: file
         '304':
           description: Content has not been modified since the date provided in the If-Modified-Since header
         '400':
@@ -5555,9 +5579,13 @@ paths:
         - $ref: '#/parameters/attachmentParam'
         - $ref: '#/parameters/ifModifiedSinceHeader'
         - $ref: '#/parameters/RangeHeader'
+      produces:
+        - application/octet-stream
       responses:
         '200':
           description: Successful response
+          schema:
+            type: file
         '206':
           description: Partial Content
         '304':
@@ -5666,9 +5694,13 @@ paths:
         - $ref: '#/parameters/attachmentParam'
         - $ref: '#/parameters/ifModifiedSinceHeader'
         - $ref: '#/parameters/RangeHeader'
+      produces:
+        - application/octet-stream
       responses:
         '200':
           description: Successful response
+          schema:
+            type: file
         '206':
           description: Partial Content
         '304':


### PR DESCRIPTION
As per [BUILDER-131](https://issues.alfresco.com/jira/browse/BUILDER-131), Currently the return type of the Get binary content REST APIs generated by swagger-codegen is *Void*, which means  we can't get the response as a binary/file in our Java clients.
This PR will fix the issue.