### PR TITLE
BUILDER-170: Fixed contentInfo sizeInBytes property.

### DIFF
--- a/src/main/webapp/definitions/alfresco-core.yaml
+++ b/src/main/webapp/definitions/alfresco-core.yaml
@@ -8131,6 +8131,7 @@ definitions:
         type: string
       sizeInBytes:
         type: integer
+        format: int64
       encoding:
         type: string
   AssociationInfo:


### PR DESCRIPTION
Without the fix, Swagger will generate an Integer rather than a Long object, which causes an exception for a large file upload.