### PR TITLE
Allow adding custom aspects to multipart upload

### DIFF
--- a/src/main/webapp/definitions/alfresco-core.yaml
+++ b/src/main/webapp/definitions/alfresco-core.yaml
@@ -1238,6 +1238,8 @@ paths:
         Also, as requesting rendition is a background process,
         any rendition failure (e.g. No transformer is currently available) will not fail the whole upload and has the potential to silently fail.
 
+        You can use the **aspectNames** field to add custom aspects.
+
         Use **overwrite** to overwrite an existing file, matched by name. If the file is versionable,
         the existing content is replaced.
 


### PR DESCRIPTION
* In conjunction with https://github.com/Alfresco/alfresco-remote-api/pull/232
* 10 May Alfresco Hackathon. Add aspectnames parameter to POST multipart children endpoint. Add unit test (https://community.alfresco.com/docs/DOC-8142-global-virtual-hack-a-thon-spring-2019)
* https://api-explorer.alfresco.com/api-explorer/#!/nodes/createNode already allow to add custom aspects to the node you create. The same should be allowed with using multipart.