### PR TITLE
SEARCH-2140 Fix SQL search example.

### DIFF
--- a/src/main/webapp/definitions/alfresco-search-sql.yaml
+++ b/src/main/webapp/definitions/alfresco-search-sql.yaml
@@ -33,8 +33,8 @@ paths:
         ```JSON
         {
           "stmt": "select * from alfresco",
-          "locales": ["en_UK"]
-          "timezone": "Europe/London"
+          "locales": ["en_UK"],
+          "timezone": "Europe/London",
           "includeMetadata":true
         }
         ```


### PR DESCRIPTION
Add the missing commas noticed while checking the timezone.

Note that the timezone is currently not supported - see SEARCH-2145.