### PR TITLE
[REPO-5168] Added Content Models API

### DIFF
--- a/src/main/webapp/definitions/alfresco-content-models.yaml
+++ b/src/main/webapp/definitions/alfresco-content-models.yaml
@@ -6,7 +6,7 @@ info:
     Provides access to information about Alfresco Content Models.
   version: '1'
   title: Alfresco Content Models REST API
-basePath: /alfresco/api/-default-/public/alfresco/versions/1
+basePath: /alfresco/api/-default-/public/model/versions/1
 securityDefinitions:
   basicAuth:
     type: basic
@@ -481,7 +481,7 @@ paths:
         '200':
           description: Successful response
           schema:
-            $ref: '#/definitions/QNamePaging'
+            $ref: '#/definitions/ConstraintPaging'
         '400':
           description: |
             Invalid parameter: value of **maxItems**, **skipCount**, **orderBy** or **modelId** is invalid
@@ -624,6 +624,7 @@ definitions:
       - namespacePrefix
       - namespaceUri
       - name
+      - id
     properties:
       namespacePrefix:
         type: string
@@ -665,9 +666,9 @@ definitions:
           title:
             description: the human-readable type title
             type: string
-          parent:
-            description: parent type definition
-            $ref: '#/definitions/Type'
+          parentId:
+            description: id of the parent type
+            type: string
           description:
             description: description of the type
             type: string
@@ -684,6 +685,20 @@ definitions:
   Aspect:
     allOf:
       - $ref: '#/definitions/QName'
+  ConstraintPaging:
+    type: object
+    properties:
+      list:
+        type: object
+        properties:
+          pagination:
+            $ref: '#/definitions/Pagination'
+          entries:
+            type: array
+            items:
+              $ref: '#/definitions/ConstraintEntry'
+          source:
+            $ref: '#/definitions/Constraint'
   ConstraintEntry:
     type: object
     required:
@@ -695,6 +710,12 @@ definitions:
     allOf:
       - $ref: '#/definitions/QName'
       - properties:
+          title:
+            description: the human-readable constraint title
+            type: string
+          description:
+            description: description of the constraint
+            type: string
           constraint:
             description: implementation details about the constrait
             type: object
@@ -728,8 +749,38 @@ definitions:
     allOf:
       - $ref: '#/definitions/QName'
     properties:
+      title:
+        description: the human-readable property title
+        type: string
+      description:
+        description: the human-readable property description
+        type: string
+      dataType:
+        description: the name of the property type
+        type: string
+      class:
+        description:  the class of the property
+        type: string
+      defaultValue:
+        description:  the default value
+        type: string 
+      multiValued:
+        description: define if the property is multi-valued
+        type: boolean
+      mandatory:
+        description: define if the property is manadatory
+        type: boolean
+      mandatoryEnforced:
+        description: define if the presence of manatory properties is enforced
+        type: boolean
+      protected:
+        description: define if the propery is system maintained
+        type: boolean
+      indexed:
+        description: define if the property is indexed
+        type: boolean
       constraints:
         description: list of constraints defined in the property
         type: array
         items:
-          $ref: '#/definitions/QName'
+          $ref: '#/definitions/Constraint'

--- a/src/main/webapp/definitions/alfresco-content-models.yaml
+++ b/src/main/webapp/definitions/alfresco-content-models.yaml
@@ -60,25 +60,25 @@ parameters:
   modelIdParam:
     name: modelId
     in: path
-    description: The namespace prefix identifier of the model.
+    description: The identifier of a model.
     required: true
     type: string
-  typeNameParam:
-    name: typeName
+  typeIdParam:
+    name: typeId
     in: path
-    description: The name identifier of a type.
+    description: The identifier of a type.
     required: true
     type: string
-  aspectNameParam:
-    name: aspectName
+  aspectIdParam:
+    name: aspectId
     in: path
-    description: The name identifier of an aspect.
+    description: The identifier of an aspect.
     required: true
     type: string
-  constraintNameParam:
-    name: constraintName
+  constraintIdParam:
+    name: constraintId
     in: path
-    description: The name identifier of a constraint.
+    description: The identifier of a constraint.
     required: true
     type: string
   propertyEntryIncludeParam:
@@ -88,11 +88,9 @@ parameters:
       A filter to include the constraints of the properties
 
       The following optional fields can be requested:
-      * constrints
+      * constraints
     required: false
     type: string
-
-
 paths:
   '/models':
     get:
@@ -121,10 +119,6 @@ paths:
         - $ref: '#/parameters/maxItemsParam'
         - $ref: '#/parameters/orderByParam'
       responses:
-        default:
-          description: Unexpected error
-          schema:
-            $ref: '#/definitions/Error'
         '200':
           description: Successful response
           schema:
@@ -134,6 +128,10 @@ paths:
             Invalid parameter: value of **maxItems** or **skipCount** or **orderBy** is invalid
         '401':
           description: Authentication failed
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
   '/models/{modelId}':
     get:
       x-alfresco-since: "6.2.2"
@@ -167,10 +165,6 @@ paths:
       parameters:
         - $ref: '#/parameters/modelIdParam'
       responses:
-        default:
-          description: Unexpected error
-          schema:
-            $ref: '#/definitions/Error'
         '200':
           description: Successful response
           schema:
@@ -185,6 +179,10 @@ paths:
         '404':
           description: |
             **modelId** does not exist
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
   '/models/{modelId}/types':
     get:
       x-alfresco-since: "6.2.2"
@@ -213,10 +211,6 @@ paths:
         - $ref: '#/parameters/maxItemsParam'
         - $ref: '#/parameters/orderByParam'
       responses:
-        default:
-          description: Unexpected error
-          schema:
-            $ref: '#/definitions/Error'
         '200':
           description: Successful response
           schema:
@@ -231,7 +225,11 @@ paths:
         '404':
           description: |
             **modelId** does not exist
-  '/models/{modelId}/types/{typeName}':
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  '/models/{modelId}/types/{typeId}':
     get:
       x-alfresco-since: "6.2.2"
       tags:
@@ -240,33 +238,33 @@ paths:
       description: |
         **Note:** this endpoint is available in Alfresco 6.2.2 and newer versions.
 
-        Get information about the type **typeName** defined in **modelId**
+        Get information about the type **typeId** defined in **modelId**
       operationId: getType
       produces:
         - application/json
       parameters:
         - $ref: '#/parameters/modelIdParam'
-        - $ref: '#/parameters/typeNameParam'
+        - $ref: '#/parameters/typeIdParam'
       responses:
-        default:
-          description: Unexpected error
-          schema:
-            $ref: '#/definitions/Error'
         '200':
           description: Successful response
           schema:
             $ref: '#/definitions/TypeEntry'
         '400':
           description: |
-            Invalid parameter: **modelName** or **typeName** is not a valid format
+            Invalid parameter: **modelId** or **typeId** is not a valid format
         '401':
           description: Authentication failed
         '403':
-          description: Current user does not have permission to retrieve **modelName**
+          description: Current user does not have permission to retrieve **modelId**
         '404':
           description: |
-            **modelName** or **typeName** does not exist
-  '/models/{modelId}/types/{typeName}/properties':
+            **modelId** or **typeId** does not exist
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  '/models/{modelId}/types/{typeId}/properties':
     get:
       x-alfresco-since: "6.2.2"
       tags:
@@ -275,9 +273,9 @@ paths:
       description: |
         **Note:** this endpoint is available in Alfresco 6.2.2 and newer versions.
 
-        Get the list of properties defined for the type **typeName**.
+        Get the list of properties defined for the type **typeId**.
 
-        You can use the **include** parameter (include=constraints) to return constraint association details 
+        You can use the **include** parameter (include=constraints) to return constraint details for each property
         for each properties.
 
         The default sort order is **name** ascending, but you can use an optional **ASC** or **DESC** 
@@ -294,31 +292,30 @@ paths:
         - application/json
       parameters:
         - $ref: '#/parameters/modelIdParam'
-        - $ref: '#/parameters/typeNameParam'
+        - $ref: '#/parameters/typeIdParam'
         - $ref: '#/parameters/skipCountParam'
         - $ref: '#/parameters/maxItemsParam'
         - $ref: '#/parameters/propertyEntryIncludeParam'
         - $ref: '#/parameters/orderByParam'
       responses:
-        default:
-          description: Unexpected error
-          schema:
-            $ref: '#/definitions/Error'
         '200':
           description: Successful response
           schema:
             $ref: '#/definitions/PropertyPaging'
         '400':
           description: |
-            Invalid parameter: value of **maxItems**, **skipCount**, **orderBy**, **modelId** or **typeName** is invalid
+            Invalid parameter: value of **maxItems**, **skipCount**, **orderBy**, **modelId** or **typeId** is invalid
         '401':
           description: Authentication failed
         '403':
           description: Current user does not have permission to retrieve **modelId**
         '404':
           description: |
-            **modelId** or **typeName** does not exist
-
+            **modelId** or **typeId** does not exist
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
   '/models/{modelId}/aspects':
     get:
       x-alfresco-since: "6.2.2"
@@ -348,10 +345,6 @@ paths:
         - $ref: '#/parameters/maxItemsParam'
         - $ref: '#/parameters/orderByParam'
       responses:
-        default:
-          description: Unexpected error
-          schema:
-            $ref: '#/definitions/Error'
         '200':
           description: Successful response
           schema:
@@ -366,7 +359,11 @@ paths:
         '404':
           description: |
             **modelId** does not exist
-  '/models/{modelId}/aspects/{aspectName}':
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  '/models/{modelId}/aspects/{aspectId}':
     get:
       x-alfresco-since: "6.2.2"
       tags:
@@ -375,33 +372,33 @@ paths:
       description: |
         **Note:** this endpoint is available in Alfresco 6.2.2 and newer versions.
 
-        Get information about the aspect **aspectName** defined in **modelId**
+        Get information about the aspect **aspectId** defined in **modelId**
       operationId: getAspect
       produces:
         - application/json
       parameters:
         - $ref: '#/parameters/modelIdParam'
-        - $ref: '#/parameters/aspectNameParam'
+        - $ref: '#/parameters/aspectIdParam'
       responses:
-        default:
-          description: Unexpected error
-          schema:
-            $ref: '#/definitions/Error'
         '200':
           description: Successful response
           schema:
             $ref: '#/definitions/AspectEntry'
         '400':
           description: |
-            Invalid parameter: value of **modelId** or **aspectName** is invalid
+            Invalid parameter: value of **modelId** or **aspectId** is invalid
         '401':
           description: Authentication failed
         '403':
-          description: Current user does not have permission to retrieve **modelName**
+          description: Current user does not have permission to retrieve **modelId**
         '404':
           description: |
-            **modelName** or **aspectName** does not exist
-  '/models/{modelId}/aspects/{aspectName}/properties':
+            **modelId** or **aspectId** does not exist
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  '/models/{modelId}/aspects/{aspectId}/properties':
     get:
       x-alfresco-since: "6.2.2"
       tags:
@@ -410,7 +407,7 @@ paths:
       description: |
         **Note:** this endpoint is available in Alfresco 6.2.2 and newer versions.
 
-        Get the list of properties defined in the aspect **aspectName**.
+        Get the list of properties defined in the aspect **aspectId**.
 
         You can use the **include** parameter (include=constraints) to return constraint association details 
         for each aspect.
@@ -429,30 +426,30 @@ paths:
         - application/json
       parameters:
         - $ref: '#/parameters/modelIdParam'
-        - $ref: '#/parameters/aspectNameParam'
+        - $ref: '#/parameters/aspectIdParam'
         - $ref: '#/parameters/skipCountParam'
         - $ref: '#/parameters/maxItemsParam'
         - $ref: '#/parameters/propertyEntryIncludeParam'
         - $ref: '#/parameters/orderByParam'
       responses:
-        default:
-          description: Unexpected error
-          schema:
-            $ref: '#/definitions/Error'
         '200':
           description: Successful response
           schema:
             $ref: '#/definitions/PropertyPaging'
         '400':
           description: |
-            Invalid parameter: value of **maxItems**, **skipCount**, **orderBy**, **modelId** or **aspectName** is invalid
+            Invalid parameter: value of **maxItems**, **skipCount**, **orderBy**, **modelId** or **aspectId** is invalid
         '401':
           description: Authentication failed
         '403':
           description: Current user does not have permission to retrieve **modelId**
         '404':
           description: |
-            **modelId** or **aspectName** does not exist
+            **modelId** or **aspectId** does not exist
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
   '/models/{modelId}/constraints':
     get:
       x-alfresco-since: "6.2.2"
@@ -481,10 +478,6 @@ paths:
         - $ref: '#/parameters/maxItemsParam'
         - $ref: '#/parameters/orderByParam'
       responses:
-        default:
-          description: Unexpected error
-          schema:
-            $ref: '#/definitions/Error'
         '200':
           description: Successful response
           schema:
@@ -499,7 +492,11 @@ paths:
         '404':
           description: |
             **modelId** does not exist
-  '/models/{modelId}/constraints/{constraintName}':
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  '/models/{modelId}/constraints/{constraintId}':
     get:
       x-alfresco-since: "6.2.2"
       tags:
@@ -508,32 +505,32 @@ paths:
       description: |
         **Note:** this endpoint is available in Alfresco 6.2.2 and newer versions.
 
-        Get information about the constraint **constraintName**
+        Get information about the constraint **constraintId**
       operationId: getConstraint
       produces:
         - application/json
       parameters:
         - $ref: '#/parameters/modelIdParam'
-        - $ref: '#/parameters/constraintNameParam'
+        - $ref: '#/parameters/constraintIdParam'
       responses:
-        default:
-          description: Unexpected error
-          schema:
-            $ref: '#/definitions/Error'
         '200':
           description: Successful response
           schema:
             $ref: '#/definitions/ConstraintEntry'
         '400':
           description: |
-            Invalid parameter: value of **modelId** or **constraintName** is invalid
+            Invalid parameter: value of **modelId** or **constraintId** is invalid
         '401':
           description: Authentication failed
         '403':
-          description: Current user does not have permission to retrieve **modelName**
+          description: Current user does not have permission to retrieve **modelId**
         '404':
           description: |
-            **modelName** or **constraintName** does not exist
+            **modelId** or **constraintId** does not exist
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
 definitions:
   Error:
     type: object
@@ -669,7 +666,7 @@ definitions:
             description: the human-readable type title
             type: string
           parent:
-            description: parent type defination
+            description: parent type definition
             $ref: '#/definitions/Type'
           description:
             description: description of the type

--- a/src/main/webapp/definitions/alfresco-content-models.yaml
+++ b/src/main/webapp/definitions/alfresco-content-models.yaml
@@ -1,0 +1,738 @@
+swagger: '2.0'
+info:
+  description: |
+    **Content Models API**
+
+    Provides access to information about Alfresco Content Models.
+  version: '1'
+  title: Alfresco Content Models REST API
+basePath: /alfresco/api/-default-/public/alfresco/versions/1
+securityDefinitions:
+  basicAuth:
+    type: basic
+    description: HTTP Basic Authentication
+security:
+  - basicAuth: []
+consumes:
+  - application/json
+produces:
+  - application/json
+tags:
+  - name: models
+    description: Retrieve and manage content models
+parameters:
+  skipCountParam:
+    name: skipCount
+    in: query
+    description: |
+      The number of entities that exist in the collection before those included in this list. 
+      If not supplied then the default value is 0.
+    required: false
+    type: integer
+    minimum: 0
+    default: 0
+  maxItemsParam:
+    name: maxItems
+    in: query
+    description: |
+      The maximum number of items to return in the list. 
+      If not supplied then the default value is 100.
+    required: false
+    type: integer
+    minimum: 1
+    default: 100
+  orderByParam:
+    name: orderBy
+    in: query
+    description: |
+      A string to control the order of the entities returned in a list. You can use the **orderBy** parameter to
+      sort the list by one or more fields.
+
+      Each field has a default sort order, which is normally ascending order. Read the API method implementation notes
+      above to check if any fields used in this method have a descending default search order.
+
+      To sort the entities in a specific order, you can use the **ASC** and **DESC** keywords for any field.
+    required: false
+    type: array
+    items:
+      type: string
+    collectionFormat: csv
+  modelIdParam:
+    name: modelId
+    in: path
+    description: The namespace prefix identifier of the model.
+    required: true
+    type: string
+  typeNameParam:
+    name: typeName
+    in: path
+    description: The name identifier of a type.
+    required: true
+    type: string
+  aspectNameParam:
+    name: aspectName
+    in: path
+    description: The name identifier of an aspect.
+    required: true
+    type: string
+  constraintNameParam:
+    name: constraintName
+    in: path
+    description: The name identifier of a constraint.
+    required: true
+    type: string
+  propertyEntryIncludeParam:
+    name: include
+    in: query
+    description: |
+      A filter to include the constraints of the properties
+
+      The following optional fields can be requested:
+      * constrints
+    required: false
+    type: string
+
+
+paths:
+  '/models':
+    get:
+      x-alfresco-since: "6.2.2"
+      tags:
+        - models
+      summary: List content models
+      description: |
+        **Note:** this endpoint is available in Alfresco 6.2.2 and newer versions.
+
+        Retrieve a list of all active content models.
+
+        The default sort order is **name** ascending, but you can use an optional **ASC** or **DESC** 
+        modifier to specify an ascending or descending sort order. 
+
+        For example, specifying ```orderBy=name DESC``` returns QName entries in descending **name** order.
+        You can specify one or more of the following fields in the **orderBy** parameter:
+        * name
+        * namespaceUri
+        * namespacePrefix       
+      operationId: listModels
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/skipCountParam'
+        - $ref: '#/parameters/maxItemsParam'
+        - $ref: '#/parameters/orderByParam'
+      responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+        '200':
+          description: Successful response
+          schema:
+            $ref: '#/definitions/QNamePaging'
+        '400':
+          description: |
+            Invalid parameter: value of **maxItems** or **skipCount** or **orderBy** is invalid
+        '401':
+          description: Authentication failed
+  '/models/{modelId}':
+    get:
+      x-alfresco-since: "6.2.2"
+      tags:
+        - models
+      summary: Get a model
+      description: |
+        **Note:** this endpoint is available in Alfresco 6.2.2 and newer versions.
+
+        Get information about the model **modelId**.
+
+        For example, we can get information about the IMAP model that has namespace prefix **"imap"** with the API call:
+        ```GET models/imap```
+
+        The result is the model identified by the prefix:
+        ```JSON
+            {
+              "entry": {
+                "namespacePrefix": "imap",
+                "namespaceUri": "http://www.alfresco.org/model/imap/1.0",
+                "name": "imapmodel",
+                "version": "1.0",
+                "author": "Alfresco",
+                "description": "IMAP Content Model"
+              }
+            }
+        ```
+      operationId: getModel
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/modelIdParam'
+      responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+        '200':
+          description: Successful response
+          schema:
+            $ref: '#/definitions/ModelEntry'
+        '400':
+          description: |
+            Invalid parameter: **modelId** is not a valid format
+        '401':
+          description: Authentication failed
+        '403':
+          description: Current user does not have permission to retrieve **modelId**
+        '404':
+          description: |
+            **modelId** does not exist
+  '/models/{modelId}/types':
+    get:
+      x-alfresco-since: "6.2.2"
+      tags:
+        - models
+      summary: List types for the model
+      description: |
+        **Note:** this endpoint is available in Alfresco 6.2.2 and newer versions.
+
+        Get the list of types defined in the model **modelId**.
+
+        The default sort order is **name** ascending, but you can use an optional **ASC** or **DESC** 
+        modifier to specify an ascending or descending sort order. 
+
+        For example, specifying ```orderBy=name DESC``` returns QName entries in descending **name** order.
+        You can specify one or more of the following fields in the **orderBy** parameter:
+        * name
+        * namespaceUri
+        * namespacePrefix  
+      operationId: listModelTypes
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/modelIdParam'
+        - $ref: '#/parameters/skipCountParam'
+        - $ref: '#/parameters/maxItemsParam'
+        - $ref: '#/parameters/orderByParam'
+      responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+        '200':
+          description: Successful response
+          schema:
+            $ref: '#/definitions/QNameEntry'
+        '400':
+          description: |
+            Invalid parameter: value of **maxItems**, **skipCount**, **orderBy** is invalid or **modelId** is not a valid format
+        '401':
+          description: Authentication failed
+        '403':
+          description: Current user does not have permission to retrieve **modelId**
+        '404':
+          description: |
+            **modelId** does not exist
+  '/models/{modelId}/types/{typeName}':
+    get:
+      x-alfresco-since: "6.2.2"
+      tags:
+        - models
+      summary: Get a type
+      description: |
+        **Note:** this endpoint is available in Alfresco 6.2.2 and newer versions.
+
+        Get information about the type **typeName** defined in **modelId**
+      operationId: getType
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/modelIdParam'
+        - $ref: '#/parameters/typeNameParam'
+      responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+        '200':
+          description: Successful response
+          schema:
+            $ref: '#/definitions/TypeEntry'
+        '400':
+          description: |
+            Invalid parameter: **modelName** or **typeName** is not a valid format
+        '401':
+          description: Authentication failed
+        '403':
+          description: Current user does not have permission to retrieve **modelName**
+        '404':
+          description: |
+            **modelName** or **typeName** does not exist
+  '/models/{modelId}/types/{typeName}/properties':
+    get:
+      x-alfresco-since: "6.2.2"
+      tags:
+        - models
+      summary: List properties for the type
+      description: |
+        **Note:** this endpoint is available in Alfresco 6.2.2 and newer versions.
+
+        Get the list of properties defined for the type **typeName**.
+
+        You can use the **include** parameter (include=constraints) to return constraint association details 
+        for each properties.
+
+        The default sort order is **name** ascending, but you can use an optional **ASC** or **DESC** 
+        modifier to specify an ascending or descending sort order. 
+
+        For example, specifying ```orderBy=name DESC``` returns properties entries in descending **name** order.
+
+        You can specify one or more of the following fields in the **orderBy** parameter:
+        * name
+        * namespaceUri
+        * namespacePrefix 
+      operationId: listTypeProperties
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/modelIdParam'
+        - $ref: '#/parameters/typeNameParam'
+        - $ref: '#/parameters/skipCountParam'
+        - $ref: '#/parameters/maxItemsParam'
+        - $ref: '#/parameters/propertyEntryIncludeParam'
+        - $ref: '#/parameters/orderByParam'
+      responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+        '200':
+          description: Successful response
+          schema:
+            $ref: '#/definitions/PropertyPaging'
+        '400':
+          description: |
+            Invalid parameter: value of **maxItems**, **skipCount**, **orderBy**, **modelId** or **typeName** is invalid
+        '401':
+          description: Authentication failed
+        '403':
+          description: Current user does not have permission to retrieve **modelId**
+        '404':
+          description: |
+            **modelId** or **typeName** does not exist
+
+  '/models/{modelId}/aspects':
+    get:
+      x-alfresco-since: "6.2.2"
+      tags:
+        - models
+      summary: List aspects for the model
+      description: |
+        **Note:** this endpoint is available in Alfresco 6.2.2 and newer versions.
+
+        Get the list of aspcts defined in the model **modelId**.
+
+        The default sort order is **name** ascending, but you can use an optional **ASC** or **DESC** 
+        modifier to specify an ascending or descending sort order. 
+
+        For example, specifying ```orderBy=name DESC``` returns QName entries in descending **name** order.
+
+        You can specify one or more of the following fields in the **orderBy** parameter:
+        * name
+        * namespaceUri
+        * namespacePrefix 
+      operationId: listModelAspects
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/modelIdParam'
+        - $ref: '#/parameters/skipCountParam'
+        - $ref: '#/parameters/maxItemsParam'
+        - $ref: '#/parameters/orderByParam'
+      responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+        '200':
+          description: Successful response
+          schema:
+            $ref: '#/definitions/QNamePaging'
+        '400':
+          description: |
+            Invalid parameter: value of **maxItems**, **skipCount**, **orderBy** or **modelId** is invalid
+        '401':
+          description: Authentication failed
+        '403':
+          description: Current user does not have permission to retrieve **modelId**
+        '404':
+          description: |
+            **modelId** does not exist
+  '/models/{modelId}/aspects/{aspectName}':
+    get:
+      x-alfresco-since: "6.2.2"
+      tags:
+        - models
+      summary: Get an aspect
+      description: |
+        **Note:** this endpoint is available in Alfresco 6.2.2 and newer versions.
+
+        Get information about the aspect **aspectName** defined in **modelId**
+      operationId: getAspect
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/modelIdParam'
+        - $ref: '#/parameters/aspectNameParam'
+      responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+        '200':
+          description: Successful response
+          schema:
+            $ref: '#/definitions/AspectEntry'
+        '400':
+          description: |
+            Invalid parameter: value of **modelId** or **aspectName** is invalid
+        '401':
+          description: Authentication failed
+        '403':
+          description: Current user does not have permission to retrieve **modelName**
+        '404':
+          description: |
+            **modelName** or **aspectName** does not exist
+  '/models/{modelId}/aspects/{aspectName}/properties':
+    get:
+      x-alfresco-since: "6.2.2"
+      tags:
+        - models
+      summary: List properties for the aspect
+      description: |
+        **Note:** this endpoint is available in Alfresco 6.2.2 and newer versions.
+
+        Get the list of properties defined in the aspect **aspectName**.
+
+        You can use the **include** parameter (include=constraints) to return constraint association details 
+        for each aspect.
+
+        The default sort order is **name** ascending, but you can use an optional **ASC** or **DESC** 
+        modifier to specify an ascending or descending sort order. 
+
+        For example, specifying ```orderBy=name DESC``` returns properties entries in descending **name** order.
+
+        You can specify one or more of the following fields in the **orderBy** parameter:
+        * name
+        * namespaceUri
+        * namespacePrefix 
+      operationId: listAspectProperties
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/modelIdParam'
+        - $ref: '#/parameters/aspectNameParam'
+        - $ref: '#/parameters/skipCountParam'
+        - $ref: '#/parameters/maxItemsParam'
+        - $ref: '#/parameters/propertyEntryIncludeParam'
+        - $ref: '#/parameters/orderByParam'
+      responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+        '200':
+          description: Successful response
+          schema:
+            $ref: '#/definitions/PropertyPaging'
+        '400':
+          description: |
+            Invalid parameter: value of **maxItems**, **skipCount**, **orderBy**, **modelId** or **aspectName** is invalid
+        '401':
+          description: Authentication failed
+        '403':
+          description: Current user does not have permission to retrieve **modelId**
+        '404':
+          description: |
+            **modelId** or **aspectName** does not exist
+  '/models/{modelId}/constraints':
+    get:
+      x-alfresco-since: "6.2.2"
+      tags:
+        - models
+      summary: List constraints for the model
+      description: |
+        **Note:** this endpoint is available in Alfresco 6.2.2 and newer versions.
+
+        Get the list of constraints defined in the model **modelId**.
+
+        The default sort order is **name** ascending, but you can use an optional **ASC** or **DESC** 
+        modifier to specify an ascending or descending sort order. 
+
+        For example, specifying ```orderBy=name DESC``` returns QName entries in descending **name** order.
+        You can specify one or more of the following fields in the **orderBy** parameter:
+        * name
+        * namespaceUri
+        * namespacePrefix 
+      operationId: listCostraints
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/modelIdParam'
+        - $ref: '#/parameters/skipCountParam'
+        - $ref: '#/parameters/maxItemsParam'
+        - $ref: '#/parameters/orderByParam'
+      responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+        '200':
+          description: Successful response
+          schema:
+            $ref: '#/definitions/QNamePaging'
+        '400':
+          description: |
+            Invalid parameter: value of **maxItems**, **skipCount**, **orderBy** or **modelId** is invalid
+        '401':
+          description: Authentication failed
+        '403':
+          description: Current user does not have permission to retrieve **modelId**
+        '404':
+          description: |
+            **modelId** does not exist
+  '/models/{modelId}/constraints/{constraintName}':
+    get:
+      x-alfresco-since: "6.2.2"
+      tags:
+        - models
+      summary: Get a constraint
+      description: |
+        **Note:** this endpoint is available in Alfresco 6.2.2 and newer versions.
+
+        Get information about the constraint **constraintName**
+      operationId: getConstraint
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/modelIdParam'
+        - $ref: '#/parameters/constraintNameParam'
+      responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+        '200':
+          description: Successful response
+          schema:
+            $ref: '#/definitions/ConstraintEntry'
+        '400':
+          description: |
+            Invalid parameter: value of **modelId** or **constraintName** is invalid
+        '401':
+          description: Authentication failed
+        '403':
+          description: Current user does not have permission to retrieve **modelName**
+        '404':
+          description: |
+            **modelName** or **constraintName** does not exist
+definitions:
+  Error:
+    type: object
+    required:
+      - error
+    properties:
+      error:
+        type: object
+        required:
+          - statusCode
+          - briefSummary
+          - stackTrace
+          - descriptionURL
+        properties:
+          errorKey:
+            type: string
+          statusCode:
+            type: integer
+            format: int32
+          briefSummary:
+            type: string
+          stackTrace:
+            type: string
+          descriptionURL:
+            type: string
+          logId:
+            type: string
+  Pagination:
+    type: object
+    required:
+      - count
+      - hasMoreItems
+      - skipCount
+      - maxItems
+    properties:
+      count:
+        type: integer
+        format: int64
+        description: |
+          The number of objects in the entries array.
+      hasMoreItems:
+        type: boolean
+        description: |
+          A boolean value which is **true** if there are more entities in the collection
+          beyond those in this response. A true value means a request with a larger value
+          for the **skipCount** or the **maxItems** parameter will return more entities.
+      totalItems:
+        type: integer
+        format: int64
+        description: |
+          An integer describing the total number of entities in the collection.
+          The API might not be able to determine this value,
+          in which case this property will not be present.
+      skipCount:
+        type: integer
+        format: int64
+        description: |
+          An integer describing how many entities exist in the collection before
+          those included in this list. If there was no **skipCount** parameter then the 
+          default value is 0.
+      maxItems:
+        type: integer
+        format: int64
+        description: |
+          The value of the **maxItems** parameter used to generate this list.
+          If there was no **maxItems** parameter then the default value is 100.
+  QNamePaging:
+    type: object
+    properties:
+      list:
+        type: object
+        properties:
+          pagination:
+            $ref: '#/definitions/Pagination'
+          entries:
+            type: array
+            items:
+              $ref: '#/definitions/QNameEntry'
+          source:
+            $ref: '#/definitions/QName'
+  QNameEntry:
+    type: object
+    required:
+      - entry
+    properties:
+      entry:
+        $ref: '#/definitions/QName'
+  QName:
+    type: object
+    required:
+      - namespacePrefix
+      - namespaceUri
+      - name
+    properties:
+      namespacePrefix:
+        type: string
+      namespaceUri:
+        type: string
+      name:
+        type: string
+  ModelEntry:
+    type: object
+    required:
+      - entry
+    properties:
+      entry:
+        $ref: '#/definitions/Model'
+  Model:
+    allOf:
+      - $ref: '#/definitions/QName'
+      - properties:
+          version:
+            description: the model version
+            type: string
+          author:
+            description: author of the model
+            type: string
+          description:
+            description: the model description
+            type: string
+  TypeEntry:
+    type: object
+    required:
+      - entry
+    properties:
+      entry:
+        $ref: '#/definitions/Type'
+  Type:
+    allOf:
+      - $ref: '#/definitions/QName'
+      - properties:
+          title:
+            description: the human-readable type title
+            type: string
+          parent:
+            description: parent type defination
+            $ref: '#/definitions/Type'
+          description:
+            description: description of the type
+            type: string
+          archive:
+            description: define if the type is archived on delete
+            type: boolean
+  AspectEntry:
+    type: object
+    required:
+      - entry
+    properties:
+      entry:
+        $ref: '#/definitions/Aspect'
+  Aspect:
+    allOf:
+      - $ref: '#/definitions/QName'
+  ConstraintEntry:
+    type: object
+    required:
+      - entry
+    properties:
+      entry:
+        $ref: '#/definitions/Constraint'
+  Constraint:
+    allOf:
+      - $ref: '#/definitions/QName'
+      - properties:
+          constraint:
+            description: implementation details about the constrait
+            type: object
+            additionalProperties:
+              type: object
+  PropertyPaging:
+    type: object
+    properties:
+      list:
+        type: object
+        properties:
+          pagination:
+            $ref: '#/definitions/Pagination'
+          entries:
+            type: array
+            items:
+              $ref: '#/definitions/PropertyEntry'
+          source:
+            $ref: '#/definitions/Property'
+  PropertyEntry:
+    type: object
+    required:
+      - entry
+    properties:
+      entry:
+        $ref: '#/definitions/Property'
+  Property:
+    type: object
+    required:
+      - mandatory
+    allOf:
+      - $ref: '#/definitions/QName'
+    properties:
+      constraints:
+        description: list of constraints defined in the property
+        type: array
+        items:
+          $ref: '#/definitions/QName'

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -125,6 +125,7 @@
           <option value="definitions/alfresco-auth.yaml">Authentication API</option>
           <option value="definitions/alfresco-discovery.yaml">Discovery API</option>
           <option value="definitions/alfresco-workflow.yaml">Workflow API</option>
+          <option value="definitions/alfresco-content-models.yaml">Content Models API</option>
         </select>
       </div>
       <div class="input">

--- a/src/test/java/org/alfresco/api/YamlToJson.java
+++ b/src/test/java/org/alfresco/api/YamlToJson.java
@@ -56,6 +56,10 @@ public class YamlToJson {
     public static final String DISCOVERY_JSON_DEFINITION = JSON_DESTINATION + "alfresco-discovery.json";
     public static final String DISCOVERY_DEFINITION_TITLE = "Alfresco Discovery REST API";
 
+    public static final String CONTENT_MODELS_DEFINITION = "/src/main/webapp/definitions/alfresco-content-models.yaml";
+    public static final String CONTENT_MODELS_JSON_DEFINITION = JSON_DESTINATION + "alfresco-content-models.json";
+    public static final String CONTENT_MODELS_DEFINITION_TITLE = "Alfresco Content Models REST API";
+
     public static void main(String[] args) {
 
         String rootPath = args[0];
@@ -88,6 +92,10 @@ public class YamlToJson {
             //Discovery
             swagger = parseSwaggerDef(new File(rootPath + DISCOVERY_DEFINITION), DISCOVERY_DEFINITION_TITLE);
             Json.mapper().writeValue(new File(rootPath + DISCOVERY_JSON_DEFINITION), swagger);
+
+            //Content Models
+            swagger = parseSwaggerDef(new File(rootPath + CONTENT_MODELS_DEFINITION), CONTENT_MODELS_DEFINITION_TITLE);
+            Json.mapper().writeValue(new File(rootPath + CONTENT_MODELS_JSON_DEFINITION), swagger);
 
         } catch (IOException e) {
             System.err.println("Failed to create a json definitions: " + e.getLocalizedMessage());

--- a/src/test/java/org/alfresco/test/APIExplorerIntegrationTest.java
+++ b/src/test/java/org/alfresco/test/APIExplorerIntegrationTest.java
@@ -78,6 +78,9 @@ public class APIExplorerIntegrationTest
 
         int discoveryAPIIndex = indexPageContent.indexOf("<option value=\"definitions/alfresco-discovery.yaml\">Discovery API</option>");
         assertTrue("Expected to find Discovery API option", discoveryAPIIndex != -1);
+        
+        int contentModelsAPIIndex = indexPageContent.indexOf("<option value=\"definitions/alfresco-content-models.yaml\">Content Models API</option>");
+        assertTrue("Expected to find Content Models API option", contentModelsAPIIndex != -1);
     }
     
     @Test
@@ -230,6 +233,29 @@ public class APIExplorerIntegrationTest
         assertTrue("Expected to find /discovery path", paths.containsKey("/discovery"));
     }
 
+    @Test
+    public void testContentModelsAPIDefinition() throws Exception
+    {
+        String contentModelsDefinitionUrl = "http://localhost:8085/api-explorer/definitions/alfresco-content-models";
+
+        // get content models definition
+        String contentModelsDefinitionContent = this.retrievePageContent(contentModelsDefinitionUrl+YAML, 200);
+
+        // make sure the content is correct
+        int swaggerIndex = contentModelsDefinitionContent.indexOf("swagger:");
+        assertTrue("Expected to find 'swagger:'", swaggerIndex != -1);
+
+        validateContentModelsDefn(contentModelsDefinitionUrl+YAML);
+        validateContentModelsDefn(contentModelsDefinitionUrl+JSON);
+    }
+
+    private void validateContentModelsDefn(String contentModelsDefinitionUrl) {
+        Swagger swagger = validateSwaggerDef(contentModelsDefinitionUrl, "Alfresco Content Models REST API", "Content Models API", "1");
+        Map<String, Path> paths = swagger.getPaths();
+        assertNotNull("Expected to retrieve a map of paths", paths);
+        assertTrue("Expected to find /models path", paths.containsKey("/models"));
+    }
+
     private Swagger validateSwaggerDef(String definitionUrl, String title, String description, String version) {
         Swagger swagger = new SwaggerParser().read(definitionUrl);
         assertNotNull("Expected the API definition to parse successfully: "+ definitionUrl, swagger);
@@ -245,7 +271,7 @@ public class APIExplorerIntegrationTest
         String defs = this.retrievePageContent("http://localhost:8085/api-explorer/definitions/index.jsp", 200);
         List<String> definitions = Json.mapper().readValue(defs, new TypeReference<List<String>>(){});
         assertNotNull(definitions);
-        assertEquals("6 definitions in 2 formats should be 12.", 12, definitions.size());
+        assertEquals("7 definitions in 2 formats should be 14.", 14, definitions.size());
     }
 
     public String retrievePageContent(String url, int expectedStatus) throws Exception


### PR DESCRIPTION
 This is a proposal of API definition to expose information about Content Models (models, properties, constraints).
We retrieve only information of entities that we think are useful because we want to keep the API as light as possible.