### PR TITLE
[REPO-5169] API Node Definitions

### DIFF
--- a/src/main/webapp/definitions/alfresco-core.yaml
+++ b/src/main/webapp/definitions/alfresco-core.yaml
@@ -9245,15 +9245,12 @@ definitions:
       title:
         description: the human-readable class title
         type: string
-      parentName:
-        description: name of the parent class
+      parentTypeId:
+        description: id of the parent type
         type: string
       description:
         description: description of the class
         type: string
-      archive:
-        description: define if the type is archived on delete
-        type: boolean
       properties:
         description: list of properties referring to the type hierarchy
         type: array
@@ -9278,22 +9275,19 @@ definitions:
       dataType:
         description: the name of the property type (i.g. d:text)
         type: string
-      class:
-        description:  the class of the property
-        type: string
-      override:
+      isOverride:
         description: define if it is an override
         type: boolean
-      multiValued:
+      isMultiValued:
         description: define if the property is multi-valued
         type: boolean
-      mandatory:
+      isMandatory:
         description: define if the property is manadatory
         type: boolean
-      mandatoryEnforced:
+      isMandatoryEnforced:
         description: define if the presence of manadatory properties is enforced
         type: boolean
-      protected:
+      isProtected:
         description: define if the property is system maintained
         type: boolean
       constraints:
@@ -9313,9 +9307,6 @@ definitions:
         type: string
       title:
         description: the human-readable constraint title
-        type: string
-      shortName:
-        description: the name of the constraint
         type: string
       description:
         description: the human-readable constraint description

--- a/src/main/webapp/definitions/alfresco-core.yaml
+++ b/src/main/webapp/definitions/alfresco-core.yaml
@@ -2511,9 +2511,10 @@ paths:
         **Note:** this endpoint is available in Alfresco 6.2.2 and newer versions.
 
         Retrieve the list of definitions for the node **nodeId**.
-        The list aims to give details about all properties and constraints applied to the node **nodeId**.
+        The list aims to give details about all properties and constraints applied to the node **nodeId** based on its type and aspects.
+        The service will return properties referring to the type hierarchy.
 
-        The default sort order for the returned list is for definitions to be sorted by ascending id.
+        The default sort order for the returned list of definitions is id ascending.
         You can override the default by using the **orderBy** parameter.
 
         You can use any of the following fields to order the results:
@@ -9351,6 +9352,9 @@ definitions:
         type: string
       shortName:
         description: the name of the constraint
+        type: string
+      description:
+        description: the human-readable constraint description
         type: string
       parameters:
         type: object

--- a/src/main/webapp/definitions/alfresco-core.yaml
+++ b/src/main/webapp/definitions/alfresco-core.yaml
@@ -2501,6 +2501,49 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
+  '/nodes/{nodeId}/definitions':
+    get:
+      x-alfresco-since: "6.2.2"
+      tags:
+        - nodes
+      summary: List definitions
+      description: |
+        **Note:** this endpoint is available in Alfresco 6.2.2 and newer versions.
+
+        Retrieve the list of definitions for the node **nodeId**.
+        The list aims to give details about all properties and constraints applied to the node **nodeId**.
+
+        The default sort order for the returned list is for definitions to be sorted by ascending id.
+        You can override the default by using the **orderBy** parameter.
+
+        You can use any of the following fields to order the results:
+        * id
+        * title
+      operationId: listNodeDefinitions
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/nodeIdParam'
+        - $ref: '#/parameters/skipCountParam'
+        - $ref: '#/parameters/maxItemsParam'
+        - $ref: '#/parameters/orderByParam'
+      responses:
+        '200':
+          description: Successful response
+          schema:
+            $ref: '#/definitions/DefinitionPaging'
+        '400':
+          description: |
+            Invalid parameter: value of **maxItems**, **skipCount** or **orderBy** is invalid
+        '401':
+          description: Authentication failed
+        '404':
+          description: |
+            **nodeId** does not exist
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
   '/nodes/{nodeId}/versions':
     get:
       x-alfresco-since: "5.2"
@@ -9232,3 +9275,84 @@ definitions:
       id:
         type: string
         description: The unique identifier of the action pending execution
+  DefinitionPaging:
+    type: object
+    properties:
+      list:
+        type: object
+        properties:
+          pagination:
+            $ref: '#/definitions/Pagination'
+          entries:
+            type: array
+            items:
+              $ref: '#/definitions/DefinitionEntry'
+  DefinitionEntry:
+    type: object
+    required:
+      - entry
+    properties:
+      entry:
+        $ref: '#/definitions/Definition'
+  Definition:
+    type: object
+    required:
+      - id
+    properties:
+      id:
+        type: string
+      title:
+        description: the human-readable title
+        type: string
+      description:
+        description: the human-readable description
+        type: string
+      defaultValue:
+        description:  the default value
+        type: string
+      dataType:
+        description: the name of the definition type (i.g. d:text)
+        type: string
+      class:
+        description:  the class of the definition
+        type: string
+      override:
+        description: define if it is an override
+        type: boolean
+      multiValued:
+        description: define if the definition is multi-valued
+        type: boolean
+      mandatory:
+        description: define if the definition is manadatory
+        type: boolean
+      mandatoryEnforced:
+        description: define if the presence of manadatory properties is enforced
+        type: boolean
+      protected:
+        description: define if the definition is system maintained
+        type: boolean
+      constraints:
+        description: list of constraints defined for the definition
+        type: array
+        items:
+          $ref: '#/definitions/Constraint'
+  Constraint:
+    type: object
+    required:
+      - id
+    properties:
+      id:
+        type: string
+      type:
+        description: the type of the constraint
+        type: string
+      title:
+        description: the human-readable constraint title
+        type: string
+      shortName:
+        description: the name of the constraint
+        type: string
+      parameters:
+        type: object
+        additionalProperties:
+          type: object

--- a/src/main/webapp/definitions/alfresco-core.yaml
+++ b/src/main/webapp/definitions/alfresco-core.yaml
@@ -167,6 +167,7 @@ parameters:
       * isLocked
       * path
       * permissions
+      * definition
     required: false
     type: array
     items:
@@ -2497,50 +2498,6 @@ paths:
           description: Current user does not have permission for **nodeId**
         '404':
           description: Target **nodeId** does not exist
-        default:
-          description: Unexpected error
-          schema:
-            $ref: '#/definitions/Error'
-  '/nodes/{nodeId}/definitions':
-    get:
-      x-alfresco-since: "6.2.2"
-      tags:
-        - nodes
-      summary: List definitions
-      description: |
-        **Note:** this endpoint is available in Alfresco 6.2.2 and newer versions.
-
-        Retrieve the list of definitions for the node **nodeId**.
-        The list aims to give details about all properties and constraints applied to the node **nodeId** based on its type and aspects.
-        The service will return properties referring to the type hierarchy.
-
-        The default sort order for the returned list of definitions is id ascending.
-        You can override the default by using the **orderBy** parameter.
-
-        You can use any of the following fields to order the results:
-        * id
-        * title
-      operationId: listNodeDefinitions
-      produces:
-        - application/json
-      parameters:
-        - $ref: '#/parameters/nodeIdParam'
-        - $ref: '#/parameters/skipCountParam'
-        - $ref: '#/parameters/maxItemsParam'
-        - $ref: '#/parameters/orderByParam'
-      responses:
-        '200':
-          description: Successful response
-          schema:
-            $ref: '#/definitions/DefinitionPaging'
-        '400':
-          description: |
-            Invalid parameter: value of **maxItems**, **skipCount** or **orderBy** is invalid
-        '401':
-          description: Authentication failed
-        '404':
-          description: |
-            **nodeId** does not exist
         default:
           description: Unexpected error
           schema:
@@ -8788,6 +8745,8 @@ definitions:
         $ref: '#/definitions/PathInfo'
       permissions:
         $ref: '#/definitions/PermissionsInfo' 
+      definition:
+        $ref: '#/definitions/Definition'
   ProbeEntry:
     type: object
     required:
@@ -9276,26 +9235,31 @@ definitions:
       id:
         type: string
         description: The unique identifier of the action pending execution
-  DefinitionPaging:
-    type: object
-    properties:
-      list:
-        type: object
-        properties:
-          pagination:
-            $ref: '#/definitions/Pagination'
-          entries:
-            type: array
-            items:
-              $ref: '#/definitions/DefinitionEntry'
-  DefinitionEntry:
-    type: object
-    required:
-      - entry
-    properties:
-      entry:
-        $ref: '#/definitions/Definition'
   Definition:
+    required:
+      - typeId
+    properties:
+      typeId:
+        description: the id of the type
+        type: string
+      title:
+        description: the human-readable class title
+        type: string
+      parentName:
+        description: name of the parent class
+        type: string
+      description:
+        description: description of the class
+        type: string
+      archive:
+        description: define if the type is archived on delete
+        type: boolean
+      properties:
+        description: list of properties referring to the type hierarchy
+        type: array
+        items:
+          $ref: '#/definitions/Property'
+  Property:
     type: object
     required:
       - id
@@ -9312,28 +9276,28 @@ definitions:
         description:  the default value
         type: string
       dataType:
-        description: the name of the definition type (i.g. d:text)
+        description: the name of the property type (i.g. d:text)
         type: string
       class:
-        description:  the class of the definition
+        description:  the class of the property
         type: string
       override:
         description: define if it is an override
         type: boolean
       multiValued:
-        description: define if the definition is multi-valued
+        description: define if the property is multi-valued
         type: boolean
       mandatory:
-        description: define if the definition is manadatory
+        description: define if the property is manadatory
         type: boolean
       mandatoryEnforced:
         description: define if the presence of manadatory properties is enforced
         type: boolean
       protected:
-        description: define if the definition is system maintained
+        description: define if the property is system maintained
         type: boolean
       constraints:
-        description: list of constraints defined for the definition
+        description: list of constraints defined for the property
         type: array
         items:
           $ref: '#/definitions/Constraint'


### PR DESCRIPTION
The API  /nodes/{nodeId} should return the current node type ( different from the content model type definition) of the dictionary in the repository. The purpose is to give all the information we need when we are using or exploring a node (properties, constrains, etc.) including inherited  properties from parents or aspects.
All the information should be retuned without the need for additional API calls.