### PR TITLE
[ACS-777] Email notification for digital workspace

### DIFF
--- a/src/main/webapp/definitions/alfresco-core.yaml
+++ b/src/main/webapp/definitions/alfresco-core.yaml
@@ -4316,19 +4316,6 @@ paths:
       parameters:
         - $ref: '#/parameters/personIdParam'
         - $ref: '#/parameters/fieldsParam'
-        - name: client
-          in: query
-          description: |
-            Optionally provided in the request query to customise the email sent.
-            **Note:** The client must be registered before this API can send an email.
-          type: string
-          required: false
-        - name: workspacePath
-          in: query
-          description: |
-            Optionally override the workspace deployment link to customise the email sent.
-          type: string
-          required: false
         - in: body
           name: siteMembershipRequestBodyCreate
           description: Site membership request details
@@ -8577,6 +8564,13 @@ definitions:
         type: string
       title:
         type: string
+      client:
+        description: |
+          Optionally provided in the request query to customise the email sent.
+          **Note:** The client must be registered before this API can send an email.
+          **Note:** this is available in Alfresco 7.0.0 and newer versions.
+        type: string
+        required: false
   SiteMembershipRequestBodyUpdate:
     type: object
     properties:

--- a/src/main/webapp/definitions/alfresco-core.yaml
+++ b/src/main/webapp/definitions/alfresco-core.yaml
@@ -4323,6 +4323,12 @@ paths:
             **Note:** The client must be registered before this API can send an email.
           type: string
           required: false
+        - name: workspacePath
+          in: query
+          description: |
+            Optionally override the workspace deployment links to customise the sent email.
+          type: string
+          required: false
         - in: body
           name: siteMembershipRequestBodyCreate
           description: Site membership request details

--- a/src/main/webapp/definitions/alfresco-core.yaml
+++ b/src/main/webapp/definitions/alfresco-core.yaml
@@ -8566,7 +8566,7 @@ definitions:
         type: string
       client:
         description: |
-          Optional client name used when sending an email to the end user, defaults to "share" if not provided..
+          Optional client name used when sending an email to the end user, defaults to "share" if not provided.
           **Note:** The client must be registered before this API can send an email.
           **Note:** This is available in Alfresco 7.0.0 and newer versions.
         type: string

--- a/src/main/webapp/definitions/alfresco-core.yaml
+++ b/src/main/webapp/definitions/alfresco-core.yaml
@@ -4316,6 +4316,13 @@ paths:
       parameters:
         - $ref: '#/parameters/personIdParam'
         - $ref: '#/parameters/fieldsParam'
+        - name: client
+          in: query
+          description: |
+            Optionally provided in the request query to customise the sent email.
+            **Note:** The client must be registered before this API can send an email.
+          type: string
+          required: false
         - in: body
           name: siteMembershipRequestBodyCreate
           description: Site membership request details

--- a/src/main/webapp/definitions/alfresco-core.yaml
+++ b/src/main/webapp/definitions/alfresco-core.yaml
@@ -8566,9 +8566,9 @@ definitions:
         type: string
       client:
         description: |
-          Optionally provided in the request query to customise the email sent.
+          Optional client name used when sending an email to the end user, defaults to "share" if not provided..
           **Note:** The client must be registered before this API can send an email.
-          **Note:** this is available in Alfresco 7.0.0 and newer versions.
+          **Note:** This is available in Alfresco 7.0.0 and newer versions.
         type: string
         required: false
   SiteMembershipRequestBodyUpdate:

--- a/src/main/webapp/definitions/alfresco-core.yaml
+++ b/src/main/webapp/definitions/alfresco-core.yaml
@@ -4319,14 +4319,14 @@ paths:
         - name: client
           in: query
           description: |
-            Optionally provided in the request query to customise the sent email.
+            Optionally provided in the request query to customise the email sent.
             **Note:** The client must be registered before this API can send an email.
           type: string
           required: false
         - name: workspacePath
           in: query
           description: |
-            Optionally override the workspace deployment links to customise the sent email.
+            Optionally override the workspace deployment link to customise the email sent.
           type: string
           required: false
         - in: body


### PR DESCRIPTION
REST APIs that send email to use an optional client name. The client name is used to lookup the custom email template and its related assets based on the registered configuration.

https://alfresco.atlassian.net/browse/ACS-777