### PR TITLE
Remove incorrectly documented ContentInfo required fields

### DIFF
--- a/src/main/webapp/definitions/alfresco-core.yaml
+++ b/src/main/webapp/definitions/alfresco-core.yaml
@@ -8724,8 +8724,6 @@ definitions:
     type: object
     required:
       - mimeType
-      - mimeTypeName
-      - sizeInBytes
     properties:
       mimeType:
         type: string


### PR DESCRIPTION
The fields are documented as required but ACS doesn't return them in certain situations.
**mimeTypeName** isn't always returned by search while **sizeInBytes** isn't returned by rendition calls.
