### PR TITLE
Add missing path information present on SharedLinks

### DIFF
--- a/src/main/webapp/definitions/alfresco-core.yaml
+++ b/src/main/webapp/definitions/alfresco-core.yaml
@@ -9237,6 +9237,8 @@ definitions:
         type: array
         items:
           type: string
+      path:
+        $ref: '#/definitions/PathInfo'
 
   RenditionBodyCreate:
     type: object


### PR DESCRIPTION
Pretty self-explanatory, path information is available but undocumented.