### PR TITLE
Properties field on person should accept structured data

### DIFF
--- a/src/main/webapp/definitions/alfresco-core.yaml
+++ b/src/main/webapp/definitions/alfresco-core.yaml
@@ -8037,8 +8037,6 @@ definitions:
           type: string
       properties:
         type: object
-        additionalProperties:
-          type: string
       capabilities:
         $ref: '#/definitions/Capabilities'
   Company:


### PR DESCRIPTION
While testing on one of the trials environment we've noticed that **properties** field on **person** returns a dictionary with values being arrays of attributes which is different to the definition and ends up raising a parsing exception with bindings that include type information.
As such this PR aims to remove the value type for the properties object on person introduced by https://github.com/Alfresco/rest-api-explorer/pull/99