### PR TITLE
Hidden warnings, added pivot example, moved error notice

### DIFF
--- a/src/main/webapp/definitions/alfresco-search.yaml
+++ b/src/main/webapp/definitions/alfresco-search.yaml
@@ -25,10 +25,6 @@ paths:
         - search
       summary: Searches Alfresco
       description: |
-        **Note**: after the migration to Swagger UI 3, this API definition is raising **two errors on the top of this page**, related to the `pivots` field.
-        As documented in [the Pull Request](https://github.com/Alfresco/rest-api-explorer/pull/118) and in [this StackOverflow Q&A](https://stackoverflow.com/q/65584131/1654265), the API definition is fine, and this will hopefully get fixed by upgrading to a future release of Swagger UI.
-        Meanwhile, remember that in the `pivots` array, `null` should be replaced by `{}`, before being populated with proper values.
-
         **Note**: this endpoint is available in Alfresco 5.2 and newer versions.
 
         **You specify all the parameters in this API in a JSON body**, URL parameters are not supported.
@@ -336,6 +332,7 @@ paths:
                   ]
               },
         ```
+        **Note**: after the migration to Swagger UI 3, this API definition was triggering some warnings, more info in [this StackOverflow Q&A](https://stackoverflow.com/q/65584131/1654265).
 
       parameters:
         - in: body
@@ -488,6 +485,11 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/RequestPivot'
+    example: # <--- Custom example
+      key: MyKey
+      pivots:
+        - key: AnotherKey
+          pivots: [ ]
   RequestLocalization:
     description: Localization settings
     type: object

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -39,6 +39,12 @@
     .topbar-wrapper .link:before {
       content:url('images/logo.svg');
     }
+
+    /* https://stackoverflow.com/a/65782841/1654265 */
+    .errors-wrapper {
+      display: none !important;
+    }
+
   </style>
 </head>
 


### PR DESCRIPTION
As in https://stackoverflow.com/a/65782841/1654265

Removed the warnings printed by Swagger UI, 
reduced the notice about them and moved it at the end of the description,
added an example for the Pivot API to prevent the `null` problem.

The branch won't be deleted, it will be used to migrate the project to Travis on a later PR.