### PR TITLE
Feature/aae 4201 enable timings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
             </goals>
             <configuration>
               <includes>META-INF/resources/webjars/swagger-ui/${swagger-ui.version}/**/*.*</includes>
-              <excludes>**/index.html,**/*.gz</excludes>
+              <excludes>**/index.html,**/*.gz,**/*.map</excludes>
               <outputDirectory>${basedir}/src/main/swagger</outputDirectory>
             </configuration>
           </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -164,10 +164,6 @@
             <manifestEntries>
               <Implementation-Version>${project.version}</Implementation-Version>
               <Build-Date>${maven.build.timestamp}</Build-Date>
-              <Build-Name>${bamboo_planName}</Build-Name>
-              <Build-Key>${bamboo_fullBuildKey}</Build-Key>
-              <Build-Number>${bamboo_buildNumber}</Build-Number>
-              <Build-Revision>${bamboo_repository_revision_number}</Build-Revision>
             </manifestEntries>
             <manifestSections>
               <manifestSection>

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -67,6 +67,7 @@
       ],
       dom_id: '#swagger-ui',
       deepLinking: true,
+      displayRequestDuration: true,
       presets: [
         SwaggerUIBundle.presets.apis,
         SwaggerUIStandalonePreset


### PR DESCRIPTION
Enabled the display of the request duration in milliseconds.

Also removed stale metadata and unnecessary .map files