### PR TITLE
ACS-2151: Initial definitions for get StorageProps endpoint.

### DIFF
--- a/src/main/webapp/definitions/alfresco-core.yaml
+++ b/src/main/webapp/definitions/alfresco-core.yaml
@@ -52,6 +52,8 @@ tags:
     description: Retrieve and manage public shared links
   - name: sites
     description: Retrieve and manage sites
+  - name: storage-info
+    description: Storage information for content
   - name: tags
     description: Retrieve and manage tags
   - name: trashcan
@@ -3197,6 +3199,40 @@ paths:
         '404':
           description: |
             **nodeId** does not exist
+  '/nodes/{nodeId}/storage-info/{contentPropName}':
+    get:
+      x-alfresco-since: "7.2.0"
+      tags:
+        - storage-info
+      summary: Retrieve storage properties for given content
+      description: |
+        **Note:** this endpoint is available in Alfresco 7.2.0 and newer versions.
+
+        Gets storage properties for given content.
+      operationId: getStorageProperties
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/nodeIdParam'
+        - name: contentPropName
+          in: path
+          description: The qualified property name of content (e.g. 'cm:content')
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          schema:
+            $ref: '#/definitions/ContentStorageInfo'
+        '400':
+          description: |
+            Invalid parameter: value of **maxItems** or **skipCount** is invalid
+        '401':
+          description: Authentication failed
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
   '/deleted-nodes':
     get:
       x-alfresco-since: "5.2"
@@ -10027,3 +10063,15 @@ definitions:
         type: object
         additionalProperties:
           type: object
+  ContentStorageInfo:
+    type: object
+    required:
+      - id
+    properties:
+      id:
+        type: string
+        description: content type property identifier (e.g. cm_content)
+      storageProperties:
+        type: object
+        additionalProperties:
+          type: string

--- a/src/main/webapp/definitions/alfresco-core.yaml
+++ b/src/main/webapp/definitions/alfresco-core.yaml
@@ -3207,8 +3207,74 @@ paths:
       summary: Retrieve storage properties for given content
       description: |
         **Note:** this endpoint is available in Alfresco 7.2.0 and newer versions.
+        It also requires at least one specific implementation of underlying functionality in Cloud Connector(s).
 
         Gets storage properties for given content.
+        Please find below sample responses for this endpoint (when Alfresco Content Connector for AWS S3 is installed).
+        Standard storage class:
+        ```json
+        {
+          "entry": {
+            "storageProperties": {
+              "x-alf-archived": "false"
+            },
+            "id": "cm:content"
+          }
+        }
+        ```
+        Intelligent tiering storage class:
+        ```json
+        {
+          "entry": {
+            "storageProperties": {
+              "x-alf-archived": "false",
+              "x-amz-storage-class": "INTELLIGENT_TIERING"
+            },
+            "id": "cm:content"
+          }
+        }
+        ```
+        Glacier archive storage class (no restore request ongoing or submitted):
+        ```json
+        {
+          "entry": {
+            "storageProperties": {
+              "x-alf-archived": "true",
+              "x-amz-storage-class": "GLACIER"
+            },
+            "id": "cm:content"
+          }
+        }
+        ```
+        Glacier archive storage class (restore request ongoing, not completed):
+        ```json
+        {
+          "entry": {
+            "storageProperties": {
+              "x-alf-archive-restore-in-progress": "true",
+              "x-amz-restore": "ongoing-request=\"true\"",
+              "x-alf-archived": "true",
+              "x-amz-storage-class": "GLACIER"
+            },
+            "id": "cm:content"
+          }
+        }
+        ```
+        Glacier archive storage class (restore request completed):
+        ```json
+        {
+          "entry": {
+            "storageProperties": {
+              "x-alf-archive-restore-in-progress": "false",
+              "x-amz-restore": "ongoing-request=\"false\", expiry-date=\"Fri Nov 26 01:00:00 CET 2021\"",
+              "x-alf-archive-restore-expiry": "2021-11-26T00:00:00.000Z",
+              "x-alf-archived": "true",
+              "x-amz-storage-class": "GLACIER"
+            },
+            "id": "cm:content"
+          }
+        }
+        ```
       operationId: getStorageProperties
       produces:
         - application/json
@@ -3216,7 +3282,9 @@ paths:
         - $ref: '#/parameters/nodeIdParam'
         - name: contentPropName
           in: path
-          description: The qualified property name of content (e.g. 'cm:content')
+          description: |
+            The namespace-prefix property name of content.
+            Delimiter between namespace-prefix and property name can be either colon (':') or underscore ('_') character (e.g., 'cm:content' or 'cm_content').
           required: true
           type: string
       responses:
@@ -3226,7 +3294,7 @@ paths:
             $ref: '#/definitions/ContentStorageInfo'
         '400':
           description: |
-            Invalid parameter: value of **maxItems** or **skipCount** is invalid
+            Invalid parameter: nodeId is not a valid format, or is not a file
         '401':
           description: Authentication failed
         default:
@@ -10070,7 +10138,8 @@ definitions:
     properties:
       id:
         type: string
-        description: content type property identifier (e.g. cm_content)
+        description: |
+          Content type property identifier (e.g. cm:content). Inside this object only colon (':') delimiter for namespace-prefix will be used.
       storageProperties:
         type: object
         additionalProperties:


### PR DESCRIPTION
This PR introduces storage properties related endpoint definitions.
It includes changes provided in [PR#141](https://github.com/Alfresco/rest-api-explorer/pull/141) which will be closed.

- Added a new GET endpoint definition to get storage properties `/nodes/{nodeId}/storage-info/{contentPropName}`
- Added 2 new POST endpoint definitions for archive (`/nodes/{nodeId}/storage-info/{contentPropName}/archive`) and archive-restore (`/nodes/{nodeId}/storage-info/{contentPropName}/archive-restore`) operations 
- Added `contentPropNameParam` path parameter definiotn
- Added `ContentStorageInfo` model object definition to handle StorageProps exposure in response
- Added request body object definitions for POST endpoints (`RestoreArchivedContentRequest`, `ArchiveContentRequest`)
- Added a new Swagger/API Explorer tag called 'storage-info' to group StoragProps related endpoints