### PR TITLE
ACS-2222 Add 412 error for Archived Content

### DIFF
--- a/src/main/webapp/definitions/alfresco-core.yaml
+++ b/src/main/webapp/definitions/alfresco-core.yaml
@@ -3355,6 +3355,9 @@ paths:
         '404':
           description: |
             **nodeId** does not exist
+        '412':
+          description: |
+            Content is archived and is inaccessible
         '501':
           description: The actual ContentStore implementation can't fulfil this request
         default:

--- a/src/main/webapp/definitions/alfresco-core.yaml
+++ b/src/main/webapp/definitions/alfresco-core.yaml
@@ -1961,6 +1961,9 @@ paths:
         '404':
           description: |
             **nodeId** does not exist
+        '412':
+          description: |
+            Content is archived and is inaccessible
         '501':
           description: The actual ContentStore implementation can't fulfil this request
         default:
@@ -2203,6 +2206,9 @@ paths:
         '404':
           description: |
             **nodeId** does not exist
+        '412':
+          description: |
+            Content is archived and is inaccessible
         '501':
           description: The actual ContentStore implementation can't fulfil this request
         default:
@@ -2869,6 +2875,9 @@ paths:
         '404':
           description: |
             **nodeId** does not exist
+        '412':
+          description: |
+            Content is archived and is inaccessible
         '501':
           description: The actual ContentStore implementation can't fulfil this request
         default:

--- a/src/main/webapp/definitions/alfresco-core.yaml
+++ b/src/main/webapp/definitions/alfresco-core.yaml
@@ -1820,6 +1820,9 @@ paths:
         '404':
           description: |
             **nodeId** does not exist
+        '412':
+          description: |
+            Content is archived and is inaccessible
         '416':
           description: |
             Range Not Satisfiable
@@ -2147,6 +2150,9 @@ paths:
         '404':
           description: |
             **nodeId** or **renditionId** does not exist
+        '412':
+          description: |
+            Content is archived and is inaccessible
         '416':
           description: Range Not Satisfiable
         default:
@@ -2810,6 +2816,9 @@ paths:
         '404':
           description: |
             **nodeId** or **versionId** does not exist
+        '412':
+          description: |
+            Content is archived and is inaccessible
         '416':
           description: Range Not Satisfiable
         default:
@@ -3103,6 +3112,9 @@ paths:
         '404':
           description: |
             **nodeId** or **versionId** or **renditionId** does not exist
+        '412':
+          description: |
+            Content is archived and is inaccessible
         '416':
           description: Range Not Satisfiable
         default:
@@ -3291,6 +3303,9 @@ paths:
         '404':
           description: |
             **nodeId** does not exist
+        '412':
+          description: |
+            Content is archived and is inaccessible
         '416':
           description: Range Not Satisfiable
         default:
@@ -3525,6 +3540,9 @@ paths:
         '404':
           description: |
             **nodeId** or **renditionId** does not exist
+        '412':
+          description: |
+            Content is archived and is inaccessible
         '416':
           description: Range Not Satisfiable
         default:
@@ -3575,6 +3593,9 @@ paths:
         '404':
           description: |
             **nodeId** does not exist
+        '412':
+          description: |
+            Content is archived and is inaccessible  
         '501':
           description: The actual ContentStore implementation can't fulfil this request
         default:
@@ -6407,6 +6428,9 @@ paths:
         '404':
           description: |
             **sharedId** does not exist
+        '412':
+          description: |
+            Content is archived and is inaccessible
         '416':
           description: Range Not Satisfiable
         '501':
@@ -6522,6 +6546,9 @@ paths:
         '404':
           description: |
             **sharedId** does not exist
+        '412':
+          description: |
+            Content is archived and is inaccessible
         '416':
           description: Range Not Satisfiable
         '501':


### PR DESCRIPTION
```yaml
'412':
          description: |
            Content is archived and is inaccessible
```
Added the above error code to the following "get (download) content" endpoints:

- GET /nodes/`{nodeId}`/content
- GET /nodes/`{nodeId}`/renditions/`{renditionId}`/content
- GET /nodes/`{nodeId}`/versions/`{versionId}`/content
- GET /nodes/`{nodeId}`/versions/`{versionId}`/renditions/`{renditionId}`/content
- GET /deleted-nodes/`{nodeId}`/content
- GET /deleted-nodes/`{nodeId}`/renditions/`{renditionId}`/content
- GET /shared-links/`{sharedId}`/content
- GET /shared-links/`{sharedId}`/renditions/`{renditionId}`/content

and also the following "request direct access url" endpoints:

- POST /nodes/`{nodeId}`/request-direct-access-url
- POST /nodes/`{nodeId}`/renditions/`{renditionId}`/request-direct-access-url
- POST /nodes/`{nodeId}`/versions/`{versionId}`/request-direct-access-url
- POST /deleted-nodes/`{nodeId}`/request-direct-access-url
- POST /deleted-nodes/`{nodeId}`/renditions/`{renditionId}`/request-direct-access-url
