### PR TITLE
[MNT-22106] Missing parenthesis in filter description

### DIFF
--- a/src/main/webapp/definitions/alfresco-core.yaml
+++ b/src/main/webapp/definitions/alfresco-core.yaml
@@ -8059,11 +8059,11 @@ paths:
 
             *   ```where=(createdByUser='jbloggs')```
 
-            *   ```where=(id BETWEEN ('1234', '4321')```
+            *   ```where=(id BETWEEN ('1234', '4321'))```
 
-            *   ```where=(createdAt BETWEEN ('2017-06-02T12:13:51.593+01:00' , '2017-06-04T10:05:16.536+01:00')```
+            *   ```where=(createdAt BETWEEN ('2017-06-02T12:13:51.593+01:00' , '2017-06-04T10:05:16.536+01:00'))```
 
-            *   ```where=(createdByUser='jbloggs' and createdAt BETWEEN ('2017-06-02T12:13:51.593+01:00' , '2017-06-04T10:05:16.536+01:00')```
+            *   ```where=(createdByUser='jbloggs' and createdAt BETWEEN ('2017-06-02T12:13:51.593+01:00' , '2017-06-04T10:05:16.536+01:00'))```
 
             *   ```where=(valuesKey='/alfresco-access/login/user')```
 
@@ -8108,8 +8108,8 @@ paths:
 
         For example:
 
-        *   ```where=(createdAt BETWEEN ('2017-06-02T12:13:51.593+01:00' , '2017-06-04T10:05:16.536+01:00')```
-        *   ```where=(id BETWEEN ('1234', '4321')```
+        *   ```where=(createdAt BETWEEN ('2017-06-02T12:13:51.593+01:00' , '2017-06-04T10:05:16.536+01:00'))```
+        *   ```where=(id BETWEEN ('1234', '4321'))```
 
         You must have admin rights to delete audit information.
       operationId: deleteAuditEntriesForAuditApp
@@ -8122,8 +8122,8 @@ paths:
           description: |
             Audit entries to permanently delete for an audit application, given an inclusive time period or range of ids. For example:
 
-            *   ```where=(createdAt BETWEEN ('2017-06-02T12:13:51.593+01:00' , '2017-06-04T10:05:16.536+01:00')```
-            *   ```where=(id BETWEEN ('1234', '4321')```
+            *   ```where=(createdAt BETWEEN ('2017-06-02T12:13:51.593+01:00' , '2017-06-04T10:05:16.536+01:00'))```
+            *   ```where=(id BETWEEN ('1234', '4321'))```
           required: true
           type: string
       responses:
@@ -8255,9 +8255,9 @@ paths:
 
             *   ```where=(createdByUser='-me-')```
 
-            *   ```where=(createdAt BETWEEN ('2017-06-02T12:13:51.593+01:00' , '2017-06-04T10:05:16.536+01:00')```
+            *   ```where=(createdAt BETWEEN ('2017-06-02T12:13:51.593+01:00' , '2017-06-04T10:05:16.536+01:00'))```
 
-            *   ```where=(createdByUser='jbloggs' and createdAt BETWEEN ('2017-06-02T12:13:51.593+01:00' , '2017-06-04T10:05:16.536+01:00')```
+            *   ```where=(createdByUser='jbloggs' and createdAt BETWEEN ('2017-06-02T12:13:51.593+01:00' , '2017-06-04T10:05:16.536+01:00'))```
           required: false
           type: string
         - $ref: '#/parameters/auditMinimalEntryIncludeParam'

--- a/src/main/webapp/definitions/alfresco-core.yaml
+++ b/src/main/webapp/definitions/alfresco-core.yaml
@@ -6126,7 +6126,7 @@ paths:
         This may be combined with the siteId filter, as shown below:
 
         ```
-        where=(siteId=mySite AND personId=person))
+        where=(siteId=mySite AND personId=person)
         ```
       operationId: getSiteMembershipRequests
       produces:


### PR DESCRIPTION
-Add missing parenthesis across multiple filter descriptions
-Remove one extra parenthesis found looking for missing parenthesis