### PR TITLE
ACS-3572 Action Constraints endpoint

### DIFF
--- a/src/main/webapp/definitions/alfresco-core.yaml
+++ b/src/main/webapp/definitions/alfresco-core.yaml
@@ -8340,85 +8340,6 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-  '/action-constraints':
-    get:
-      x-alfresco-since: "7.3.0"
-      tags:
-        - actions
-      summary: Retrieve a list of all action parameter constraints
-      description: |
-        **Note:** this endpoint is available in Alfresco 7.3.0 and newer versions.
-
-        Gets a list of action parameter constraints
-        Sample reposne:
-        ```
-        {
-        	"list": {
-        		"pagination": {
-        			"count": 2,
-        			"hasMoreItems": false,
-        			"totalItems": 2,
-        			"skipCount": 0,
-        			"maxItems": 100
-        		},
-        		"entries": [
-        			{
-                           "entry": {
-                               "constraintValues": [
-                                   {
-                                       "value": "051a82f6-b897-462a-a189-3abefc506fb0",
-                                       "label": "notify_user_email_nl.html.ftl",
-                                       "isNode": true
-                                   },
-                                   {
-                                       "value": "adeb274a-0517-4658-8c80-e36eb6bb1f52",
-                                       "label": "notify_user_email_es.html.ftl",
-                                       "isNode": true
-                                   }
-                               ],
-                               "constraintName": "ac-email-templates"
-                           }
-                       },
-
-        			{
-        				"entry": {
-                                "constraintValues": [
-                                    {
-                                        "value": "MIME_TYPE",
-                                        "label": "Mimetype"
-                                    },
-                                    {
-                                        "value": "ENCODING",
-                                        "label": "Encoding"
-                                    },
-                                    {
-                                        "value": "SIZE",
-                                        "label": "Size"
-                                    }
-                                ],
-                                "constraintName": "ac-content-properties"
-        			}
-        	   ]
-           }
-        }
-        ```
-      operationId: listActionConstraints
-      produces:
-        - application/json
-      parameters:
-        - $ref: '#/parameters/maxItemsParam'
-        - $ref: '#/parameters/skipCountParam'
-      responses:
-        '200':
-          description: Successful response
-          schema:
-            $ref: '#/definitions/ActionConstraintPaging'
-        '401':
-          description: Authentication failed
-        default:
-          description: Unexpected error
-          schema:
-            $ref: '#/definitions/Error'
   '/action-constraints/{actionConstraintName}':
     get:
       x-alfresco-since: "7.3.0"
@@ -11161,7 +11082,7 @@ definitions:
       Response object holding action parameter constraint name and map of its values-labels.
     type: object
     properties:
-      name:
+      constraintName:
         type: string
         description: |
           Name of the constraint.
@@ -11239,23 +11160,6 @@ definitions:
     properties:
       entry:
         $ref: '#/definitions/ActionConstraint'
-  ActionConstraintPaging:
-    type: object
-    required:
-      - list
-    properties:
-      list:
-        type: object
-        required:
-          - pagination
-          - entries
-        properties:
-          pagination:
-            $ref: '#/definitions/Pagination'
-          entries:
-            type: array
-            items:
-              $ref: '#/definitions/ActionConstraintEntry'
   ActionDefinitionList:
     type: object
     properties:

--- a/src/main/webapp/definitions/alfresco-core.yaml
+++ b/src/main/webapp/definitions/alfresco-core.yaml
@@ -11150,9 +11150,6 @@ definitions:
       label:
         description: Constraint display label
         type: string
-      isNode:
-        description: True if value is a node id
-        type: boolean
   ActionConstraintEntry:
     type: object
     required:

--- a/src/main/webapp/definitions/alfresco-core.yaml
+++ b/src/main/webapp/definitions/alfresco-core.yaml
@@ -557,6 +557,12 @@ parameters:
       * -isInheritanceEnabled- (boolean) - Whether the folder inherits rule sets from its parent(s)
     required: true
     type: string
+  constraintNamesFilterParam:
+    name: names
+    in: query
+    description: |
+      Comma separated list of action parameter constraint names to be returned in the response.
+    type: string
 paths:
   '/nodes/{nodeId}/comments':
     get:
@@ -8333,6 +8339,38 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
+  '/action-constraints':
+    get:
+      x-alfresco-since: "7.3.0"
+      tags:
+        - actions
+      summary: Retrieve a list of action parameter constraints
+      description: |
+        **Note:** this endpoint is available in Alfresco 7.3.0 and newer versions.
+
+        Gets a list of action parameter constraints
+
+        One can filter the response by constraint name passed in a query parameter **names** (multiple names can be comma separated).
+      operationId: listActionConstraints
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/maxItemsParam'
+        - $ref: '#/parameters/skipCountParam'
+        - $ref: '#/parameters/constraintNamesFilterParam'
+      responses:
+        '200':
+          description: Successful response
+          schema:
+            $ref: '#/definitions/ActionConstraintPaging'
+        '401':
+          description: Authentication failed
+        '404':
+          description: Contraint(s) for given names not found
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
   '/action-definitions':
       get:
         x-alfresco-since: "5.2.2"
@@ -11027,6 +11065,45 @@ definitions:
          format: date-time
       values:
         type: object
+  ActionConstraint:
+    description: |
+      Response object holding action parameter constraint name and map of its values-labels.
+    type: object
+    properties:
+      name:
+        type: string
+        description: |
+          Name of the constraint.
+      constraintsMap:
+        description: |
+          A map (String-String) of constraint values and labels.
+        type: object
+        additionalProperties:
+          type: string
+  ActionConstraintEntry:
+    type: object
+    required:
+      - entry
+    properties:
+      entry:
+        $ref: '#/definitions/ActionConstraint'
+  ActionConstraintPaging:
+    type: object
+    required:
+      - list
+    properties:
+      list:
+        type: object
+        required:
+          - pagination
+          - entries
+        properties:
+          pagination:
+            $ref: '#/definitions/Pagination'
+          entries:
+            type: array
+            items:
+              $ref: '#/definitions/ActionConstraintEntry'
   ActionDefinitionList:
     type: object
     properties:

--- a/src/main/webapp/definitions/alfresco-core.yaml
+++ b/src/main/webapp/definitions/alfresco-core.yaml
@@ -8340,7 +8340,7 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-  '/action-constraints/{parameterConstraintName}':
+  '/action-parameter-constraints/{parameterConstraintName}':
     get:
       x-alfresco-since: "7.3.0"
       tags:

--- a/src/main/webapp/definitions/alfresco-core.yaml
+++ b/src/main/webapp/definitions/alfresco-core.yaml
@@ -8363,26 +8363,40 @@ paths:
         		},
         		"entries": [
         			{
-        				"entry": {
-        				   "name": "ac-types",
-        				   "constraintsMap": {
-        					   "cm:content": "Content",
-        					   "cm:authority": "Alfresco Authority Abstract Type",
-        					   "usr:user": "Alfresco User Type",
-        					   "usr:authority": "Alfresco Authority Abstract Type",
-        					   "rule:rule": "Rule"
-        				   }
-        			   }
-        		   },
+                           "entry": {
+                               "constraintValues": [
+                                   {
+                                       "value": "051a82f6-b897-462a-a189-3abefc506fb0",
+                                       "label": "notify_user_email_nl.html.ftl",
+                                       "isNode": true
+                                   },
+                                   {
+                                       "value": "adeb274a-0517-4658-8c80-e36eb6bb1f52",
+                                       "label": "notify_user_email_es.html.ftl",
+                                       "isNode": true
+                                   }
+                               ],
+                               "constraintName": "ac-email-templates"
+                           }
+                       },
+
         			{
         				"entry": {
-        					"constraintsMap": {
-        						"MIME_TYPE": "Mimetype",
-        						"ENCODING": "Encoding",
-        						"SIZE": "Size"
-        					},
-        					"name": "ac-content-properties"
-        				}
+                                "constraintValues": [
+                                    {
+                                        "value": "MIME_TYPE",
+                                        "label": "Mimetype"
+                                    },
+                                    {
+                                        "value": "ENCODING",
+                                        "label": "Encoding"
+                                    },
+                                    {
+                                        "value": "SIZE",
+                                        "label": "Size"
+                                    }
+                                ],
+                                "constraintName": "ac-content-properties"
         			}
         	   ]
            }
@@ -8419,18 +8433,15 @@ paths:
         ```
         {
           "entry": {
-            "name": "ac-mimetypes",
-            "constraintsMap": {
-              "application/acp": "Alfresco Content Package",
-              "application/dita+xml": "DITA",
-              "application/eps": "EPS Type PostScript",
-              "application/framemaker": "Adobe FrameMaker",
-              "application/illustrator": "Adobe Illustrator File",
-              "application/java": "Java Class",
-              "application/java-archive": "Java Archive",
-              "application/json": "JSON"
-            }
-          }
+                  "constraintValues": [
+                      {
+                          "value": "fa41fd6e-5640-410f-9f3e-93f268186f69",
+                          "label": "Start Pooled Review and Approve Workflow",
+                          "isNode": true
+                      }
+                  ],
+                  "constraintName": "ac-scripts"
+              }
         }
         ```
       operationId: getActionConstraint
@@ -11154,25 +11165,73 @@ definitions:
         type: string
         description: |
           Name of the constraint.
-      constraintsMap:
+      constraintValues:
+        type: array
+        items:
+          $ref: '#/definitions/ActionConstraintData'
         description: |
-          A map (String-String) of constraint possbile value (map's key) and corresponding label (map's value).
+          A list of constraint possbile values along with additional data (label, isNode flag).
           Sample object could be:
           ```JSON
-          "constraintsMap": {
-                                 "EQUALS": "Equals",
-                                 "CONTAINS": "Contains",
-                                 "BEGINS": "Begins With",
-                                 "ENDS": "Ends With",
-                                 "GREATER_THAN": "Greater Than",
-                                 "GREATER_THAN_EQUAL": "Greater Than Or Equal To",
-                                 "LESS_THAN": "Less Than",
-                                 "LESS_THAN_EQUAL": "Less Than Or Equal To"
-                             }
+          "constraintValues": [
+                     {
+                        "value": "EQUALS",
+                        "label": "Equals"
+                     },
+                     {
+                        "value": "CONTAINS",
+                        "label": "Contains"
+                     },
+                     {
+                        "value": "BEGINS",
+                        "label": "Begins With"
+                     },
+                     {
+                        "value": "ENDS",
+                        "label": "Ends With"
+                     },
+                     {
+                        "value": "GREATER_THAN",
+                        "label": "Greater Than"
+                     },
+                     {
+                        "value": "GREATER_THAN_EQUAL",
+                        "label": "Greater Than Or Equal To"
+                     },
+                     {
+                        "value": "LESS_THAN",
+                        "label": "Less Than"
+                     },
+                     {
+                        "value": "LESS_THAN_EQUAL",
+                        "label": "Less Than Or Equal To"
+                     }
+                  ]
           ```
-        type: object
-        additionalProperties:
-          type: string
+          or
+          ```JSON
+          "constraintValues": [
+                                  {
+                                      "value": "fa41fd6e-5640-410f-9f3e-93f268186f69",
+                                      "label": "Start Pooled Review and Approve Workflow",
+                                      "isNode": true
+                                  }
+                              ]
+          ```
+  ActionConstraintData:
+    type: object
+    required:
+      - value
+    properties:
+      value:
+        description: Constraint value (this can also be a node id)
+        type: string
+      label:
+        description: Constraint display label
+        type: string
+      isNode:
+        description: True if value is a node id
+        type: boolean
   ActionConstraintEntry:
     type: object
     required:

--- a/src/main/webapp/definitions/alfresco-core.yaml
+++ b/src/main/webapp/definitions/alfresco-core.yaml
@@ -557,7 +557,7 @@ parameters:
       * -isInheritanceEnabled- (boolean) - Whether the folder inherits rule sets from its parent(s)
     required: true
     type: string
-  actionConstraintNameParam:
+  parameterConstraintNameParam:
     name: names
     in: path
     required: true
@@ -8340,7 +8340,7 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-  '/action-constraints/{actionConstraintName}':
+  '/action-constraints/{parameterConstraintName}':
     get:
       x-alfresco-since: "7.3.0"
       tags:
@@ -8369,7 +8369,7 @@ paths:
       produces:
         - application/json
       parameters:
-        - $ref: '#/parameters/actionConstraintNameParam'
+        - $ref: '#/parameters/parameterConstraintNameParam'
       responses:
         '200':
           description: Successful response
@@ -11223,7 +11223,8 @@ definitions:
         type: boolean
       displayLabel:
         type: string
-
+      parameterConstraintName:
+        type: string
   ActionBodyExec:
     type: object
     required:

--- a/src/main/webapp/definitions/alfresco-core.yaml
+++ b/src/main/webapp/definitions/alfresco-core.yaml
@@ -557,11 +557,12 @@ parameters:
       * -isInheritanceEnabled- (boolean) - Whether the folder inherits rule sets from its parent(s)
     required: true
     type: string
-  constraintNamesFilterParam:
+  actionConstraintNameParam:
     name: names
-    in: query
+    in: path
+    required: true
     description: |
-      Comma separated list of action parameter constraint names to be returned in the response.
+      Action parameter constraint name to be returned in the response.
     type: string
 paths:
   '/nodes/{nodeId}/comments':
@@ -8344,20 +8345,55 @@ paths:
       x-alfresco-since: "7.3.0"
       tags:
         - actions
-      summary: Retrieve a list of action parameter constraints
+      summary: Retrieve a list of all action parameter constraints
       description: |
         **Note:** this endpoint is available in Alfresco 7.3.0 and newer versions.
 
         Gets a list of action parameter constraints
-
-        One can filter the response by constraint name passed in a query parameter **names** (multiple names can be comma separated).
+        Sample reposne:
+        ```
+        {
+        	"list": {
+        		"pagination": {
+        			"count": 2,
+        			"hasMoreItems": false,
+        			"totalItems": 2,
+        			"skipCount": 0,
+        			"maxItems": 100
+        		},
+        		"entries": [
+        			{
+        				"entry": {
+        				   "name": "ac-types",
+        				   "constraintsMap": {
+        					   "cm:content": "Content",
+        					   "cm:authority": "Alfresco Authority Abstract Type",
+        					   "usr:user": "Alfresco User Type",
+        					   "usr:authority": "Alfresco Authority Abstract Type",
+        					   "rule:rule": "Rule"
+        				   }
+        			   }
+        		   },
+        			{
+        				"entry": {
+        					"constraintsMap": {
+        						"MIME_TYPE": "Mimetype",
+        						"ENCODING": "Encoding",
+        						"SIZE": "Size"
+        					},
+        					"name": "ac-content-properties"
+        				}
+        			}
+        	   ]
+           }
+        }
+        ```
       operationId: listActionConstraints
       produces:
         - application/json
       parameters:
         - $ref: '#/parameters/maxItemsParam'
         - $ref: '#/parameters/skipCountParam'
-        - $ref: '#/parameters/constraintNamesFilterParam'
       responses:
         '200':
           description: Successful response
@@ -8365,8 +8401,52 @@ paths:
             $ref: '#/definitions/ActionConstraintPaging'
         '401':
           description: Authentication failed
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  '/action-constraints/{actionConstraintName}':
+    get:
+      x-alfresco-since: "7.3.0"
+      tags:
+        - actions
+      summary: Retrieve an action parameter constraint by requested name
+      description: |
+        **Note:** this endpoint is available in Alfresco 7.3.0 and newer versions.
+
+        Gets action parameter constraint by requested name.
+        Sample reposne:
+        ```
+        {
+          "entry": {
+            "name": "ac-mimetypes",
+            "constraintsMap": {
+              "application/acp": "Alfresco Content Package",
+              "application/dita+xml": "DITA",
+              "application/eps": "EPS Type PostScript",
+              "application/framemaker": "Adobe FrameMaker",
+              "application/illustrator": "Adobe Illustrator File",
+              "application/java": "Java Class",
+              "application/java-archive": "Java Archive",
+              "application/json": "JSON"
+            }
+          }
+        }
+        ```
+      operationId: getActionConstraint
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/actionConstraintNameParam'
+      responses:
+        '200':
+          description: Successful response
+          schema:
+            $ref: '#/definitions/ActionConstraintEntry'
+        '401':
+          description: Authentication failed
         '404':
-          description: Contraint(s) for given names not found
+          description: Contraint with given name not found
         default:
           description: Unexpected error
           schema:
@@ -11076,7 +11156,20 @@ definitions:
           Name of the constraint.
       constraintsMap:
         description: |
-          A map (String-String) of constraint values and labels.
+          A map (String-String) of constraint possbile value (map's key) and corresponding label (map's value).
+          Sample object could be:
+          ```JSON
+          "constraintsMap": {
+                                 "EQUALS": "Equals",
+                                 "CONTAINS": "Contains",
+                                 "BEGINS": "Begins With",
+                                 "ENDS": "Ends With",
+                                 "GREATER_THAN": "Greater Than",
+                                 "GREATER_THAN_EQUAL": "Greater Than Or Equal To",
+                                 "LESS_THAN": "Less Than",
+                                 "LESS_THAN_EQUAL": "Less Than Or Equal To"
+                             }
+          ```
         type: object
         additionalProperties:
           type: string


### PR DESCRIPTION
Changed path parameter name (from `actionConstraintName` to `parameterConstraintName`) to be the same as `action-definitions` endpoint returns in reponse.
Added missing (`parameterConstraintName`) in response object for `action-definitions` endpoint.
Removing `isNode` from `ActionConstraintData` object.