### PR TITLE
ACS-4022: Fixing the path for category related endpoints.

### DIFF
--- a/src/main/webapp/definitions/alfresco-core.yaml
+++ b/src/main/webapp/definitions/alfresco-core.yaml
@@ -7056,7 +7056,7 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-  '/category/{categoryId}':
+  '/categories/{categoryId}':
     get:
       x-alfresco-since: "7.4"
       tags:


### PR DESCRIPTION
I am not sure if the path `/category/{categoryId}` was meant here or that was only sort of TYPO but I believe that if we want to be consistent with all other V1 endpoints, we should make this change (although we don't have GET all categories endpoint designed or planned yet).