### PR TITLE
Update GET /tags to support getting tags by name

### DIFF
--- a/src/main/webapp/definitions/alfresco-core.yaml
+++ b/src/main/webapp/definitions/alfresco-core.yaml
@@ -6896,7 +6896,7 @@ paths:
         - name: where
           in: query
           description: |
-            Optionally filter the list. Supported options are:
+            Optionally filter the list. The only supported options are:
 
             * ```where=(tag='tagName')```
 
@@ -6904,7 +6904,7 @@ paths:
             
             * ```where=(tag matches ('*tag*'))```
             
-            OR operator is supported.
+            OR operator is also supported.
           required: false
           type: string
       produces:

--- a/src/main/webapp/definitions/alfresco-core.yaml
+++ b/src/main/webapp/definitions/alfresco-core.yaml
@@ -6902,7 +6902,7 @@ paths:
 
             * ```where=(tag in ('tag1', 'tag2'))```
             
-            * ```where=(tag matches ('tag*'))```
+            * ```where=(tag matches ('*tag*'))```
             
             OR operator is supported.
           required: false

--- a/src/main/webapp/definitions/alfresco-core.yaml
+++ b/src/main/webapp/definitions/alfresco-core.yaml
@@ -6884,7 +6884,7 @@ paths:
         You can use the **include** parameter to return additional **values** information.
 
         You can sort the result list using the **orderBy** parameter. You can specify one or more of the following fields in the **orderBy** parameter:
-        * name
+        * tag
         * count
       operationId: listTags
       parameters:
@@ -6896,11 +6896,15 @@ paths:
         - name: where
           in: query
           description: |
-            Optionally filter the list. The only supported options are:
+            Optionally filter the list. Supported options are:
 
-            * ```where=(name='tagName')```
+            * ```where=(tag='tagName')```
 
-            * ```where=(name in ('tag1', 'tag2'))```
+            * ```where=(tag in ('tag1', 'tag2'))```
+            
+            * ```where=(tag matches ('tag*'))```
+            
+            OR operator is supported.
           required: false
           type: string
       produces:


### PR DESCRIPTION
https://alfresco.atlassian.net/browse/ACS-4023
This PR is about updating field `name` to `tag` in where query.