### PR TITLE
ACS-4966 Add path to Category model

### DIFF
--- a/src/main/webapp/definitions/alfresco-core.yaml
+++ b/src/main/webapp/definitions/alfresco-core.yaml
@@ -228,6 +228,18 @@ parameters:
     description: |
       Returns additional information about the category. The following optional fields can be requested:
       * count
+      * path
+    required: false
+    type: array
+    items:
+      type: string
+    collectionFormat: csv
+  categoryEntryIncludePathParam:
+    name: include
+    in: query
+    description: |
+      Returns additional information about the category. The following optional fields can be requested:
+      * path
     required: false
     type: array
     items:
@@ -1019,6 +1031,7 @@ paths:
         - $ref: '#/parameters/nodeIdParam'
         - $ref: '#/parameters/skipCountParam'
         - $ref: '#/parameters/maxItemsParam'
+        - $ref: '#/parameters/categoryEntryIncludePathParam'
         - $ref: '#/parameters/fieldsParam'
       responses:
         '200':
@@ -1100,6 +1113,7 @@ paths:
         - application/json
       parameters:
         - $ref: '#/parameters/nodeIdParam'
+        - $ref: '#/parameters/categoryEntryIncludePathParam'
         - $ref: '#/parameters/fieldsParam'
         - in: body
           name: categoryLinkBodyCreate

--- a/src/main/webapp/definitions/alfresco-core.yaml
+++ b/src/main/webapp/definitions/alfresco-core.yaml
@@ -9793,6 +9793,9 @@ definitions:
       count:
         type: number
         description: The number of nodes that are assigned to this category.
+      path:
+        type: string
+        description: The path to this category.
   CategoryBody:
     type: object
     required:


### PR DESCRIPTION
https://alfresco.atlassian.net/browse/ACS-4966
This PR is about adding `path` param to Categories API.