### PR TITLE
ACS-5829 Add pagination parameters to targets and sources.

### DIFF
--- a/src/main/webapp/definitions/alfresco-core.yaml
+++ b/src/main/webapp/definitions/alfresco-core.yaml
@@ -2825,6 +2825,8 @@ paths:
           required: false
           type: string
         - $ref: '#/parameters/nodeAssocMinimalEntryIncludeParam'
+        - $ref: '#/parameters/skipCountParam'
+        - $ref: '#/parameters/maxItemsParam'
         - $ref: '#/parameters/fieldsParam'
       responses:
         '200':
@@ -2915,6 +2917,8 @@ paths:
           required: false
           type: string
         - $ref: '#/parameters/nodeAssocMinimalEntryIncludeParam'
+        - $ref: '#/parameters/skipCountParam'
+        - $ref: '#/parameters/maxItemsParam'
         - $ref: '#/parameters/fieldsParam'
       responses:
         '200':


### PR DESCRIPTION
The support for this already exists, but it was missed when creating the API explorer definitions.