### PR TITLE
[MNT-25185] Add authority display name to permissions

### DIFF
--- a/src/main/webapp/definitions/alfresco-core.yaml
+++ b/src/main/webapp/definitions/alfresco-core.yaml
@@ -10636,6 +10636,9 @@ definitions:
         enum:
          - ALLOWED
          - DENIED
+      authorityDisplayName:
+        type: string
+        readOnly: true
   PermissionsInfo:
     type: object
     properties:


### PR DESCRIPTION
- New field was introduced for NodePermission
- Making it readOnly as this field is part of the response and not the request
- Linked PR for reference - https://github.com/Alfresco/alfresco-community-repo/pull/3992