### PR TITLE
new swagger definitions for checkout and cancel-checkout apis for PRODMAN-904

### DIFF
--- a/src/main/webapp/definitions/alfresco-core.yaml
+++ b/src/main/webapp/definitions/alfresco-core.yaml
@@ -1963,7 +1963,7 @@ paths:
       summary: Checkout a node
       description: |
         **Note:** this endpoint is available in Alfresco 5.2 and newer versions.
-        
+
         Checks out the file node **nodeId** for offline editing.
 
         A private working copy is created and the original node is locked.
@@ -2010,7 +2010,7 @@ paths:
       summary: Cancel checkout for a node
       description: |
         **Note:** this endpoint is available in Alfresco 5.2 and newer versions.
-        
+
         Cancel the checkout workflow for the node **nodeId**.
 
         The private working copy is deleted and the original node is unlocked.
@@ -2050,7 +2050,7 @@ paths:
             $ref: '#/definitions/Error'
   '/nodes/{nodeId}/move':
     post:
-      x-alfresco-since: "5.2"
+      x-alfresco-since:  "5.2"
       tags:
         - nodes
       summary: Move a node

--- a/src/main/webapp/definitions/alfresco-core.yaml
+++ b/src/main/webapp/definitions/alfresco-core.yaml
@@ -1955,6 +1955,95 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
+  '/nodes/{nodeId}/checkout':
+    post:
+      x-alfresco-since: "5.2"
+      tags:
+        - nodes
+      summary: Checkout a node
+      description: |
+        Checks out the file node **nodeId** for offline editing.
+
+        A private working copy is created and the original node is locked.
+        The working copy node is returned.
+
+        Only files (cm:content or subtypes) can be checked out.
+      operationId: checkoutNode
+      parameters:
+        - $ref: '#/parameters/nodeIdParam'
+        - $ref: '#/parameters/nodeEntryIncludeParam'
+        - $ref: '#/parameters/fieldsParam'
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: Successful response
+          schema:
+            $ref: '#/definitions/NodeEntry'
+        '400':
+          description: |
+            Invalid parameter: **nodeId** is not a file node
+        '401':
+          description: Authentication failed
+        '403':
+          description: |
+            Current user does not have permission to checkout **nodeId**
+        '404':
+          description: |
+            **nodeId** does not exist
+        '409':
+          description: |
+            **nodeId** is already checked out or locked
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  '/nodes/{nodeId}/cancel-checkout':
+    post:
+      x-alfresco-since: "5.2"
+      tags:
+        - nodes
+      summary: Cancels the checkout workflow for a Node
+      description: |
+        Cancel the checkout workflow for the node **nodeId**.
+
+        The private working copy is deleted and the original node is unlocked.
+        The original node is returned.
+
+      operationId: cancelCheckoutNode
+      parameters:
+        - $ref: '#/parameters/nodeIdParam'
+        - $ref: '#/parameters/nodeEntryIncludeParam'
+        - $ref: '#/parameters/fieldsParam'
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: Successful response
+          schema:
+            $ref: '#/definitions/NodeEntry'
+        '400':
+          description: |
+            Invalid parameter: **nodeId** is not a file node
+        '401':
+          description: Authentication failed
+        '403':
+          description: |
+            Current user does not have permission to checkout **nodeId**
+        '404':
+          description: |
+            **nodeId** does not exist
+        '409':
+          description: |
+            **nodeId** is already checked out or locked
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
   '/nodes/{nodeId}/move':
     post:
       x-alfresco-since: "5.2"

--- a/src/main/webapp/definitions/alfresco-core.yaml
+++ b/src/main/webapp/definitions/alfresco-core.yaml
@@ -1962,6 +1962,8 @@ paths:
         - nodes
       summary: Checkout a node
       description: |
+        **Note:** this endpoint is available in Alfresco 5.2 and newer versions.
+        
         Checks out the file node **nodeId** for offline editing.
 
         A private working copy is created and the original node is locked.
@@ -1984,7 +1986,7 @@ paths:
             $ref: '#/definitions/NodeEntry'
         '400':
           description: |
-            Invalid parameter: **nodeId** is not a file node
+            Invalid parameter: **nodeId** is not a valid format, or is not a file node
         '401':
           description: Authentication failed
         '403':
@@ -2005,8 +2007,10 @@ paths:
       x-alfresco-since: "5.2"
       tags:
         - nodes
-      summary: Cancels the checkout workflow for a Node
+      summary: Cancel checkout for a node
       description: |
+        **Note:** this endpoint is available in Alfresco 5.2 and newer versions.
+        
         Cancel the checkout workflow for the node **nodeId**.
 
         The private working copy is deleted and the original node is unlocked.
@@ -2028,18 +2032,18 @@ paths:
             $ref: '#/definitions/NodeEntry'
         '400':
           description: |
-            Invalid parameter: **nodeId** is not a file node
+            Invalid parameter: **nodeId** is not a valid format, or is not a file node
         '401':
           description: Authentication failed
         '403':
           description: |
-            Current user does not have permission to checkout **nodeId**
+            Current user does not have permission to cancel checkout **nodeId**
         '404':
           description: |
             **nodeId** does not exist
         '409':
           description: |
-            **nodeId** is already checked out or locked
+            **nodeId** is not checked out
         default:
           description: Unexpected error
           schema:


### PR DESCRIPTION
This pull request adds two new API endpoints to the `alfresco-core.yaml` OpenAPI definition, enhancing support for file check-out workflows. The new endpoints allow clients to check out a file node for offline editing and to cancel an existing checkout, aligning the API with common document management scenarios.

**New API endpoints for node checkout workflow:**

* Added a `POST /nodes/{nodeId}/checkout` endpoint to allow checking out a file node for offline editing, which creates a private working copy and locks the original node. Returns the working copy node and handles various error scenarios such as invalid node type, lack of permissions, non-existent node, or node already checked out/locked.
* Added a `POST /nodes/{nodeId}/cancel-checkout` endpoint to allow canceling the checkout workflow for a node, deleting the private working copy and unlocking the original node. Returns the original node and handles similar error scenarios as the checkout endpoint.